### PR TITLE
Comment out logging of bytes received from child process

### DIFF
--- a/sbt-rc/parent/src/main/scala/com/typesafe/sbtrc/ProcessActor.scala
+++ b/sbt-rc/parent/src/main/scala/com/typesafe/sbtrc/ProcessActor.scala
@@ -83,9 +83,9 @@ class ProcessActor(builder: ProcessBuilder, textMode: Boolean = true) extends Ac
   }
 
   private def bufferEvent(event: ProcessEvent): Unit = {
-    if (log.isDebugEnabled) {
-      log.debug("Buffering process event {}", event)
-    }
+    //if (log.isDebugEnabled) {
+    //  log.debug("Buffering process event {}", event)
+    //}
 
     if (!flushScheduled) {
       // timeout length is intended to be user-imperceptible, but greater than OS timer resolution,


### PR DESCRIPTION
This is too noisy even for debug loglevel. Uncomment it
if you need it...
