### PR TITLE
Wip/proxy support

### DIFF
--- a/remote-controller/src/main/scala/com/typesafe/sbtrc/launching/BasicSbtLauncher.scala
+++ b/remote-controller/src/main/scala/com/typesafe/sbtrc/launching/BasicSbtLauncher.scala
@@ -61,7 +61,7 @@ trait BasicSbtProcessLauncher extends SbtProcessLauncher {
       case n if n startsWith "http." => true
       case n if n startsWith "https." => true
       case n if n startsWith "ftp." => true
-      case n if n startsWith "user.home" => true
+      case n if n startsWith "socksProxy" => true
       case n if n startsWith "sbt" => true
       case n if n startsWith "ivy" => true
       case _ => false


### PR DESCRIPTION
This adds support for *.nonProxyHosts properties and SOCKS proxy properties.
I also would like to add user.home to pass-through properties to be able to override broken home paths on Windows.
