### PR TITLE
Don't bind http properties which play uses.

### DIFF
--- a/remote-controller/src/main/scala/com/typesafe/sbtrc/launching/BasicSbtLauncher.scala
+++ b/remote-controller/src/main/scala/com/typesafe/sbtrc/launching/BasicSbtLauncher.scala
@@ -57,6 +57,11 @@ trait BasicSbtProcessLauncher extends SbtProcessLauncher {
 
   def isPassThroughProperty(name: String): Boolean =
     name match {
+      // Ignore play stuff, or we break it.
+      case "http.port" => false
+      case "http.address" => false
+      case "https.port" => false
+      case "https.address" => false
       // TODO - What else should pass through?
       case n if n startsWith "http." => true
       case n if n startsWith "https." => true


### PR DESCRIPTION
TODO - We should convince them to use a play namespace.  Right
now we assume the http._, https._, sbt.\* and ivy.\* namespaces are the
correct ones to pass through.  We should:

(a) Make this configureable
(b) Try to figure out who isn't namespacing the environemnt vars.

Review by @havocp 
