### PR TITLE
Add all remote dependencies to local IT repository and bump to sbt 0.13.

### DIFF
--- a/integration-tests/src/main/scala/com/typesafe/sbtrc/CanRunSbt13EclipseProject.scala
+++ b/integration-tests/src/main/scala/com/typesafe/sbtrc/CanRunSbt13EclipseProject.scala
@@ -13,7 +13,7 @@ import akka.pattern.ask
 
 /** Ensures that we can make requests and receive responses from our children. */
 class CanRunSbt13EclipseProject extends SbtProcessLauncherTest {
-  val dummy = utils.makeDummySbtProject("runChild13", "0.13.0-RC4")
+  val dummy = utils.makeDummySbtProject("runChild13", "0.13.0")
   val eclipsePluginFile = new File(dummy, "project/eclipse.sbt")
   sbt.IO.write(eclipsePluginFile,
     """

--- a/integration-tests/src/main/scala/com/typesafe/sbtrc/CanRunSbt13IdeaProject.scala
+++ b/integration-tests/src/main/scala/com/typesafe/sbtrc/CanRunSbt13IdeaProject.scala
@@ -13,7 +13,7 @@ import akka.pattern.ask
 
 /** Ensures that we can make requests and receive responses from our children. */
 class CanRunSbt13IdeaProject extends SbtProcessLauncherTest {
-  val dummy = utils.makeDummySbtProject("runChild13-idea", "0.13.0-RC4")
+  val dummy = utils.makeDummySbtProject("runChild13-idea", "0.13.0")
   val ideaPluginFile = new File(dummy, "project/idea.sbt")
   sbt.IO.write(ideaPluginFile,
     """addSbtPlugin("com.github.mpeltonen" % "sbt-idea" % "1.5.1")""")

--- a/integration-tests/src/main/scala/com/typesafe/sbtrc/CanRunSbt13Project.scala
+++ b/integration-tests/src/main/scala/com/typesafe/sbtrc/CanRunSbt13Project.scala
@@ -12,7 +12,7 @@ import akka.util.Timeout
 
 /** Ensures that we can make requests and receive responses from our children. */
 class CanRunSbt13Project extends SbtProcessLauncherTest {
-  val dummy = utils.makeDummySbtProject("runChild13", "0.13.0-RC3")
+  val dummy = utils.makeDummySbtProject("runChild13", "0.13.0")
   val child = SbtProcess(system, dummy, sbtProcessLauncher)
   try {
     Await.result(child ? RunRequest(sendEvents = false, mainClass = None), timeout.duration) match {

--- a/project/build.scala
+++ b/project/build.scala
@@ -156,12 +156,18 @@ object TheBuild extends Build {
       //com.typesafe.sbtidea.SbtIdeaPlugin.ideaIgnoreModule := true,
       Keys.publish := {},
       Keys.publishLocal := {},
-      // Additional dependencies required to run tests:
+      // Additional dependencies required to run tests (so we don't re-resolve them):
       localRepoArtifacts += "org.scala-lang" % "scala-compiler" % "2.10.1",
       localRepoArtifacts += "org.scala-lang" % "scala-compiler" % "2.10.2",
       localRepoArtifacts += "org.scala-lang" % "scala-compiler" % "2.9.2",
       localRepoArtifacts += "com.typesafe.play" % "play_2.10" % "2.2.0-RC1",
       localRepoArtifacts += Defaults.sbtPluginExtra("com.typesafe.play" % "sbt-plugin" % "2.2.0-RC1", "0.13", "2.10"),
+      localRepoArtifacts += Defaults.sbtPluginExtra("com.typesafe.sbt" % "sbt-atmos" % "0.3.0-RC1", "0.13", "2.10"),
+      // TODO - does this exist?
+      localRepoArtifacts += Defaults.sbtPluginExtra("com.typesafe.sbt" % "sbt-atmos" % "0.3.0-RC1", "0.12", "2.9.2"),
+      localRepoArtifacts += Defaults.sbtPluginExtra("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "2.2.0", "0.13", "2.10"),
+      localRepoArtifacts += Defaults.sbtPluginExtra("com.github.mpeltonen" % "sbt-idea" % "1.5.1", "0.13", "2.10"),
+      localRepoArtifacts += "com.novocode" % "junit-interface" % "0.7" % "test",
       Keys.resolvers += Resolver.url("typesafe-ivy-releases-2", new URL("http://private-repo.typesafe.com/typesafe/ivy-releases"))(Resolver.ivyStylePatterns)
     )
   )


### PR DESCRIPTION
This should hopefully prevent timeout errors in jenkins. (or at least speed up the slow builds).

Review by @havocp.
