### PR TITLE
Sbt version should come from project/build.properties

### DIFF
--- a/integration-tests/src/main/scala/com/typesafe/sbtrc/CanLaunchWithProvidedFiles.scala
+++ b/integration-tests/src/main/scala/com/typesafe/sbtrc/CanLaunchWithProvidedFiles.scala
@@ -15,8 +15,9 @@ class CanLaunchWithProvidedFiles extends SbtProcessLauncherTest {
   // Here we try to mimic a file-provided example, but we load jars through the launcher ahead of time.
   // Twisting our wheels around the axel, for fun.
   val sbtFileProvidedProcessLauncher: SbtProcessLauncher = {
-    val cp =
-      sbtProcessLauncher.sbt012support.extraJars ++ sbtProcessLauncher.sbt012support.controllerClasspath
+    // Some ugly hackery
+    val support = sbtProcessLauncher.getLaunchInfo("0.12", "0.12.4").asInstanceOf[SbtDefaultPropsfileLaunchInfo]
+    val cp = support.extraJars ++ support.controllerClasspath
     println("Sbt probe jars = " + cp.mkString(","))
     val jar = sbtProcessLauncher.sbtLauncherJar
     new FileProvidedSbtProcessLauncher(jar, cp, localRepositories)

--- a/remote-controller/src/main/scala/com/typesafe/sbtrc/launching/BasicSbtLauncher.scala
+++ b/remote-controller/src/main/scala/com/typesafe/sbtrc/launching/BasicSbtLauncher.scala
@@ -83,15 +83,18 @@ trait BasicSbtProcessLauncher extends SbtProcessLauncher {
    * Returns the versoin specific information
    *  launch sbt for the given project.
    *  @param version The sbt binary version to use
+   *  @param fulLVersion the complete sbt version
    */
-  def getLaunchInfo(version: String): SbtBasicProcessLaunchInfo
+  def getLaunchInfo(version: String, fullVersion: String): SbtBasicProcessLaunchInfo
 
   /** Returns an sbt launcher jar we can use to launch this process. */
   def sbtLauncherJar: File
 
-  /** Returns the sbt binary version we're about to fork. */
-  def getSbtBinaryVersion(cwd: File): String =
-    io.SbtVersionUtil.findProjectBinarySbtVersion(cwd).getOrElse("0.12")
+  /** Returns the sbt verison + binary version we're about to fork. */
+  def getSbtVersions(cwd: File): (String, String) =
+    // TODO - Put this in sbt version util!
+    io.SbtVersionUtil.findProjectSbtVersion(cwd).getOrElse("0.12.4") ->
+      io.SbtVersionUtil.findProjectBinarySbtVersion(cwd).getOrElse("0.12")
 
   /**
    * Generates the arguments used by the sbt process launcher.
@@ -102,8 +105,8 @@ trait BasicSbtProcessLauncher extends SbtProcessLauncher {
     // we have no idea if computers will be able to handle this amount of
     // memory....
     val defaultJvmArgs = jvmArgs ++ passThroughJvmArgs
-    val sbtBinaryVersion = getSbtBinaryVersion(cwd)
-    val info = getLaunchInfo(sbtBinaryVersion)
+    val (sbtFullVersion, sbtBinaryVersion) = getSbtVersions(cwd)
+    val info = getLaunchInfo(sbtBinaryVersion, sbtFullVersion)
     // TODO - handle spaces in strings and such...
     val sbtProps = Seq(
       // TODO - Remove this junk once we don't have to hack our classes into sbt's classloader.

--- a/remote-controller/src/main/scala/com/typesafe/sbtrc/launching/DefaultSbtProcessLauncher.scala
+++ b/remote-controller/src/main/scala/com/typesafe/sbtrc/launching/DefaultSbtProcessLauncher.scala
@@ -41,9 +41,7 @@ class DefaultSbtProcessLauncher(
    * Our published support for sbt 0.12.
    *  TODO - clean this code up.  We should autocreate app names and scala versions based on sbt version...
    */
-  object sbt012support extends SbtDefaultPropsfileLaunchInfo {
-    // TODO - better property name
-    override val sbtVersion = SBT_VERSION
+  case class Sbt012support(sbtVersion: String) extends SbtDefaultPropsfileLaunchInfo {
     // The Application for the controller jars.  We can use this to get the classpath.
     private object probeApp extends LookupApplicationId(
       name = "sbt-rc-probe-0-12",
@@ -62,12 +60,10 @@ class DefaultSbtProcessLauncher(
     override val optionalRepositories = optRepositories
   }
   /**
-   * Our published support for sbt 0.12.
+   * Our published support for sbt 0.13.
    *  TODO - clean this code up.  We should autocreate app names and scala versions based on sbt version...
    */
-  object sbt013support extends SbtDefaultPropsfileLaunchInfo {
-    // TODO - better property name
-    override val sbtVersion = "0.13.0-RC3"
+  case class Sbt013support(sbtVersion: String) extends SbtDefaultPropsfileLaunchInfo {
     // The Application for the controller jars.  We can use this to get the classpath.
     private object probeApp extends LookupApplicationId(
       name = "sbt-rc-probe-0-13",
@@ -85,10 +81,10 @@ class DefaultSbtProcessLauncher(
       launcher.app(uiPlugin, "2.10.2").mainClasspath
     override val optionalRepositories = optRepositories
   }
-  override def getLaunchInfo(version: String): SbtBasicProcessLaunchInfo =
+  override def getLaunchInfo(version: String, fullVersion: String): SbtBasicProcessLaunchInfo =
     version match {
-      case "0.12" => sbt012support
-      case "0.13" => sbt013support
+      case "0.12" => Sbt012support(fullVersion)
+      case "0.13" => Sbt013support(fullVersion)
       case _ => sys.error(s"sbt version $version is not supported!")
     }
 }

--- a/remote-controller/src/main/scala/com/typesafe/sbtrc/launching/FileProvidedSbtProcessLauncher.scala
+++ b/remote-controller/src/main/scala/com/typesafe/sbtrc/launching/FileProvidedSbtProcessLauncher.scala
@@ -21,31 +21,30 @@ class FileProvidedSbtProcessLauncher(
   optRepos: Seq[SbtPropertiesHelper.Repository] = Nil) extends BasicSbtProcessLauncher {
 
   // Support objects for the various sbts.
-  object sbt12Support extends SbtDefaultPropsfileLaunchInfo {
+  case class Sbt12Support(sbtVersion: String) extends SbtDefaultPropsfileLaunchInfo {
     val myFiles =
       probeFiles.filter(_.getName contains "0-12") ++
         probeFiles.filter(_.getName contains "sbt-rc-props")
     override val controllerClasspath: Seq[File] = myFiles filterNot (_.getName contains "ui-interface")
     override val extraJars: Seq[File] = myFiles filter (_.getName contains "ui-interface")
     // TODO - Get this version from properties!
-    override val sbtVersion = "0.12.4"
     override val optionalRepositories = optRepos
   }
-  object sbt13Support extends SbtDefaultPropsfileLaunchInfo {
+  case class Sbt13Support(sbtVersion: String) extends SbtDefaultPropsfileLaunchInfo {
     val myFiles =
       probeFiles.filter(_.getName contains "0-13") ++
         probeFiles.filter(_.getName contains "sbt-rc-props")
     override val controllerClasspath: Seq[File] = myFiles filterNot (_.getAbsolutePath contains "ui-interface")
     override val extraJars: Seq[File] = myFiles filter (_.getAbsolutePath contains "ui-interface")
     // TODO - Get this version from properties!
-    override val sbtVersion = "0.13.0-RC3"
     override val optionalRepositories = optRepos
   }
 
-  override def getLaunchInfo(version: String): SbtBasicProcessLaunchInfo =
+  override def getLaunchInfo(version: String, fullVersion: String): SbtBasicProcessLaunchInfo =
     version match {
-      case "0.12" => sbt12Support
-      case "0.13" => sbt13Support
+      // TODO - We only support 0.12.4+
+      case "0.12" => Sbt12Support(fullVersion)
+      case "0.13" => Sbt13Support(fullVersion)
       case _ => sys.error("Unsupported sbt version: " + version)
     }
 


### PR DESCRIPTION
Wire build.properties sbt.version all the way through, the way we intended.

Review by @havocp 
