### PR TITLE
Fixes #35 - Bump to sbt 0.12.4 for old versions.

### DIFF
--- a/commons/protocol/src/main/scala/com/typesafe/sbtrc/io/SbtVersionUtil.scala
+++ b/commons/protocol/src/main/scala/com/typesafe/sbtrc/io/SbtVersionUtil.scala
@@ -14,6 +14,24 @@ object SbtVersionUtil {
     finally reader.close()
     Option(props.getProperty("sbt.version"))
   }
+  
+  object SbtVersionNeedsUpgraded {
+    def unapply(x: String): Boolean = x match {
+      case "0.12.0" => true
+      case "0.12.1" => true
+      case "0.12.2" => true
+      case "0.12.3" => true
+      case _ => false
+    }
+  }
+  
+  def findSafeProjectSbtVersion(root: File): Option[String] = {
+    findProjectSbtVersion(root) map {
+      // Here we need to upgrade the sbt version to 0.12.4 for our hooks.
+      case SbtVersionNeedsUpgraded() => "0.12.4"
+      case x => x
+    }
+  }
 
   def findProjectBinarySbtVersion(root: File): Option[String] =
     findProjectSbtVersion(root) map toBinaryVersion

--- a/integration-tests/src/main/scala/com/typesafe/sbtrc/CanTalkToSbtOldChild.scala
+++ b/integration-tests/src/main/scala/com/typesafe/sbtrc/CanTalkToSbtOldChild.scala
@@ -1,0 +1,32 @@
+package com.typesafe.sbtrc
+
+import com.typesafe.sbtrc.protocol._
+import com.typesafe.sbtrc.it._
+import java.io.File
+import akka.actor._
+import akka.pattern._
+import akka.dispatch._
+import concurrent.duration._
+import concurrent.Await
+import akka.util.Timeout
+
+/** Ensures that we can make requests and receive responses from our children. */
+class CanTalkToSbtOldChild extends SbtProcessLauncherTest {
+  val dummy = utils.makeDummySbtProject("talkToChild", sbtVersion = "0.12.3")
+  val child = SbtProcess(system, dummy, sbtProcessLauncher)
+
+  try {
+    val name = Await.result(child ? NameRequest(sendEvents = false), timeout.duration) match {
+      case NameResponse(n, _) => n
+    }
+    assertEquals("talkToChild", name)
+
+    val name2 = Await.result(child ? NameRequest(sendEvents = false), timeout.duration) match {
+      case NameResponse(n, _) => n
+    }
+    assertEquals("talkToChild", name2)
+
+  } finally {
+    system.stop(child)
+  }
+}

--- a/remote-controller/src/main/scala/com/typesafe/sbtrc/launching/BasicSbtLauncher.scala
+++ b/remote-controller/src/main/scala/com/typesafe/sbtrc/launching/BasicSbtLauncher.scala
@@ -93,7 +93,7 @@ trait BasicSbtProcessLauncher extends SbtProcessLauncher {
   /** Returns the sbt verison + binary version we're about to fork. */
   def getSbtVersions(cwd: File): (String, String) =
     // TODO - Put this in sbt version util!
-    io.SbtVersionUtil.findProjectSbtVersion(cwd).getOrElse("0.12.4") ->
+    io.SbtVersionUtil.findSafeProjectSbtVersion(cwd).getOrElse("0.12.4") ->
       io.SbtVersionUtil.findProjectBinarySbtVersion(cwd).getOrElse("0.12")
 
   /**


### PR DESCRIPTION
Here we bump to sbt 0.12.4 when forking sbt so that the apply -cp
hooks are available.  For all projects used in activator, this is a
safe operation, and should remain so.

Review by @havocp cc @jamesward
