### PR TITLE
Checks whether to add Echo shim or not based on Echo supported version o...

### DIFF
--- a/probe/0.12/probe/src/main/scala/com/typesafe/sbtrc/controller/AkkaSupport.scala
+++ b/probe/0.12/probe/src/main/scala/com/typesafe/sbtrc/controller/AkkaSupport.scala
@@ -17,4 +17,18 @@ object AkkaSupport {
       hasAkka getOrElse false
     }
   }
+
+  def validAkkaVersion(state: State, maxVersion: String): Boolean = {
+    val (_, classpath: Seq[Attributed[File]]) = extract(state).runTask(Keys.dependencyClasspath in Compile, state)
+    classpath exists { f =>
+      val validAkka =
+        for {
+          id <- f.get(Keys.moduleID.key)
+          if id.organization == "com.typesafe.akka"
+          if id.name contains "akka"
+          if EchoSupport.convertVersionString(id.revision) <= EchoSupport.convertVersionString(maxVersion)
+        } yield true
+      validAkka getOrElse false
+    }
+  }
 }

--- a/probe/0.12/probe/src/main/scala/com/typesafe/sbtrc/controller/EchoSupport.scala
+++ b/probe/0.12/probe/src/main/scala/com/typesafe/sbtrc/controller/EchoSupport.scala
@@ -32,12 +32,24 @@ object EchoSupport {
     PoorManDebug.trace("Checking if sbt-echo is enabled.")
     val extracted = Project.extract(state)
     val settings = extracted.session.mergeSettings
-    findEchoKey(EchoTracePort, settings).isDefined
+    val supportsEcho = findEchoKey(EchoTracePort, settings).isDefined
+    val supportsAkka =
+      if (AkkaSupport.isAkkaProject(state)) AkkaSupport.validAkkaVersion(state, BuildInfo.supportedAkkaVersionSbt012)
+      else true
+    val supportsPlay =
+      if (isPlayProject(state)) PlaySupport.validPlayVersion(state, BuildInfo.supportedPlayVersionSbt012)
+      else true
+    supportsEcho && supportsAkka && supportsPlay
   }
 
   def installEchoSupport(origState: State, tracePort: Option[Int]): State = {
     if (tracePort.isDefined && isEchoProject(origState)) {
       setTracePort(origState, tracePort.get)
     } else origState
+  }
+
+  def convertVersionString(version: String): Int = {
+    val index = if (version.contains("-")) version.indexOf("-") else version.length
+    version.substring(0, index).replace(".", "").toInt
   }
 }

--- a/probe/0.12/probe/src/main/scala/com/typesafe/sbtrc/controller/PlaySupport.scala
+++ b/probe/0.12/probe/src/main/scala/com/typesafe/sbtrc/controller/PlaySupport.scala
@@ -150,4 +150,18 @@ object PlaySupport {
     if (isPlayProject(origState)) installHooks(origState, ui)
     else origState
   }
+
+  def validPlayVersion(state: State, maxVersion: String): Boolean = {
+    val (_, classpath: Seq[Attributed[File]]) = Project.extract(state).runTask(Keys.dependencyClasspath in Compile, state)
+    classpath exists { f =>
+      val validPlay =
+        for {
+          id <- f.get(Keys.moduleID.key)
+          if id.organization == "com.typesafe.play"
+          if id.name contains "play"
+          if EchoSupport.convertVersionString(id.revision) <= EchoSupport.convertVersionString(maxVersion)
+        } yield true
+      validPlay getOrElse false
+    }
+  }
 }

--- a/probe/0.13/probe/src/main/scala/com/typesafe/sbtrc/controller/AkkaSupport.scala
+++ b/probe/0.13/probe/src/main/scala/com/typesafe/sbtrc/controller/AkkaSupport.scala
@@ -18,4 +18,18 @@ object AkkaSupport {
       hasAkka getOrElse false
     }
   }
+
+  def validAkkaVersion(state: State, maxVersion: String): Boolean = {
+    val (_, classpath: Seq[Attributed[File]]) = extract(state).runTask(Keys.dependencyClasspath in Compile, state)
+    classpath exists { f =>
+      val validAkka =
+        for {
+          id <- f.get(Keys.moduleID.key)
+          if id.organization == "com.typesafe.akka"
+          if id.name contains "akka"
+          if EchoSupport.convertVersionString(id.revision) <= EchoSupport.convertVersionString(maxVersion)
+        } yield true
+      validAkka getOrElse false
+    }
+  }
 }

--- a/probe/0.13/probe/src/main/scala/com/typesafe/sbtrc/controller/PlaySupport.scala
+++ b/probe/0.13/probe/src/main/scala/com/typesafe/sbtrc/controller/PlaySupport.scala
@@ -145,4 +145,18 @@ object PlaySupport {
     if (isPlayProject(origState)) installHooks(origState, ui)
     else origState
   }
+
+  def validPlayVersion(state: State, maxVersion: String): Boolean = {
+    val (_, classpath: Seq[Attributed[File]]) = Project.extract(state).runTask(Keys.dependencyClasspath in Compile, state)
+    classpath exists { f =>
+      val validPlay =
+        for {
+          id <- f.get(Keys.moduleID.key)
+          if id.organization == "com.typesafe.play"
+          if id.name contains "play"
+          if EchoSupport.convertVersionString(id.revision) <= EchoSupport.convertVersionString(maxVersion)
+        } yield true
+      validPlay getOrElse false
+    }
+  }
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -23,7 +23,12 @@ object Dependencies {
   val sbt12ScalaVersion = getScalaVersionForSbtVersion(sbt12Version)
   val sbt13Version = "0.13.0"
   val sbt13ScalaVersion = getScalaVersionForSbtVersion(sbt13Version)
+  // Make sure to upgrade supported versions below when updating the sbt-echo version
   val sbtEchoDefaultVersion = "0.1.0"
+  val sbt012AtmosSupportedAkkaVersion = "2.2.1"
+  val sbt012AtmosSupportedPlayVersion = "2.1.4"
+  val sbt013AtmosSupportedAkkaVersion = "2.2.1"
+  val sbt013AtmosSupportedPlayVersion = "2.2.0"
 
   // Here are the versions used for the core project
   val scalaVersion = "2.10.1"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,3 @@
 addSbtPlugin("com.typesafe.sbt" % "sbt-scalariform" % "1.0.1")
+
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.2.5")

--- a/project/sbtrc.scala
+++ b/project/sbtrc.scala
@@ -4,6 +4,7 @@ import com.typesafe.sbt.SbtScalariform
 import com.typesafe.sbt.SbtScalariform.ScalariformKeys
 import com.typesafe.sbt.SbtGit
 import Dependencies.getScalaVersionForSbtVersion
+import sbtbuildinfo.Plugin._ 
 
 object SbtRcBuild {
 
@@ -51,9 +52,17 @@ object SbtRcBuild {
     )
 
   def sbtProbeSettings(sbtVersion: String): Seq[Setting[_]] =
+    buildInfoSettings ++
     Seq(
       scalaVersion := getScalaVersionForSbtVersion(sbtVersion),
-      Keys.sbtVersion := sbtVersion
+      Keys.sbtVersion := sbtVersion,
+      sourceGenerators in Compile <+= buildInfo,
+      buildInfoKeys ++= Seq[BuildInfoKey](
+        "supportedAkkaVersionSbt012" -> Dependencies.sbt012AtmosSupportedAkkaVersion,
+        "supportedPlayVersionSbt012" -> Dependencies.sbt012AtmosSupportedPlayVersion,
+        "supportedAkkaVersionSbt013" -> Dependencies.sbt013AtmosSupportedAkkaVersion,
+        "supportedPlayVersionSbt013" -> Dependencies.sbt013AtmosSupportedPlayVersion),
+      buildInfoPackage := "com.typesafe.sbtrc"
     )
 
   def sbtShimPluginSettings(sbtVersion: String): Seq[Setting[_]] =


### PR DESCRIPTION
...f Akka and Play.

Checks the supported version based on hard coded values in the Dependencies.scala file. Not the most elegant solution but it gets the job done. In order for an Echo shim to be added it needs to fulfil all of the following criteria:
- If Akka present the version <= supported version (sbt 0.12 = Akka 2.2.1 and sbt 0.13 = Akka 2.2.1)
- If Play present version <= supported version (sbt 0.12 = Play 2.1.4 and sbt 0.13 = Play 2.2.0)
- Has Echo enabled
