### PR TITLE
Register uuid / configName / humanReadableName for each client

### DIFF
--- a/client/src/main/scala/com/typesafe/sbtrc/client/DebugClient.scala
+++ b/client/src/main/scala/com/typesafe/sbtrc/client/DebugClient.scala
@@ -3,10 +3,16 @@ package client
 
 import java.net._
 import sbt.client._
+import sbt.protocol.RegisterClientRequest
+import sbt.protocol.registerClientRequestFormat
 
 object DebugClient {
   def apply(port: Int): SbtClient = {
     val client = new ipc.Client(new Socket("127.0.0.1", port))
-    new SimpleSbtClient(client, closeHandler = () => ())
+    val uuid = java.util.UUID.randomUUID()
+    val configName = "debug-client"
+    val humanReadableName = "Debug Client"
+    client.sendJson(RegisterClientRequest(uuid.toString, configName, humanReadableName))
+    new SimpleSbtClient(uuid, configName, humanReadableName, client, closeHandler = () => ())
   }
 }

--- a/client/src/main/scala/com/typesafe/sbtrc/client/SimpleClient.scala
+++ b/client/src/main/scala/com/typesafe/sbtrc/client/SimpleClient.scala
@@ -19,7 +19,10 @@ import java.io.EOFException
  *
  * This is only to do proof of concept work and flesh out the server.
  */
-class SimpleSbtClient(client: ipc.Client, closeHandler: () => Unit) extends SbtClient {
+class SimpleSbtClient(override val uuid: java.util.UUID,
+  override val configName: String,
+  override val humanReadableName: String,
+  client: ipc.Client, closeHandler: () => Unit) extends SbtClient {
 
   def watchBuild(listener: BuildStructureListener)(implicit ex: ExecutionContext): Subscription =
     buildEventManager.watch(listener)(ex)

--- a/client/src/main/scala/sbt/client/SbtClient.scala
+++ b/client/src/main/scala/sbt/client/SbtClient.scala
@@ -7,6 +7,10 @@ import concurrent.{ ExecutionContext, Future }
 /** This represents a connection to the Sbt server, and all the actions that can be performed against an active sbt build. */
 trait SbtClient extends Closeable {
 
+  def uuid: java.util.UUID
+  def configName: String
+  def humanReadableName: String
+
   /**
    * This is our mechanism of watching the build structure to see when it changes,
    * and update our information about the build.

--- a/commons/protocol/src/main/scala/sbt/protocol/Protocol.scala
+++ b/commons/protocol/src/main/scala/sbt/protocol/Protocol.scala
@@ -38,6 +38,8 @@ sealed trait Event extends Message
 //              Requests (Reactive API)
 // ------------------------------------------
 
+case class RegisterClientRequest(uuid: String, configName: String, humanReadableName: String) extends Request
+
 case class ExecutionRequest(command: String) extends Request
 case class ExecutionDone(command: String) extends Event
 case class ExecutionFailure(command: String) extends Event

--- a/commons/protocol/src/main/scala/sbt/protocol/WireProtocol.scala
+++ b/commons/protocol/src/main/scala/sbt/protocol/WireProtocol.scala
@@ -17,6 +17,7 @@ import language.existentials
 object WireProtocol {
 
   private val messages: Map[Class[_], (String, Format[_])] = Map(
+    msg[RegisterClientRequest],
     msg[RequestCompleted],
     msg[RequestFailed],
     msg[ReadLineRequest],

--- a/commons/protocol/src/main/scala/sbt/protocol/package.scala
+++ b/commons/protocol/src/main/scala/sbt/protocol/package.scala
@@ -182,6 +182,7 @@ package object protocol {
     def reads(value: JsValue): JsResult[TestOutcome] =
       JsSuccess(TestOutcome(value.as[String]))
   }
+  implicit val registerClientRequestFormat = Json.format[RegisterClientRequest]
   implicit val testEventFormat = Json.format[TestEvent]     
   implicit val executionRequestFormat = Json.format[ExecutionRequest]
   implicit val executionDoneFormat = Json.format[ExecutionDone]

--- a/integration-tests/src/main/scala/com/typesafe/sbtrc/it/SbtClientTest.scala
+++ b/integration-tests/src/main/scala/com/typesafe/sbtrc/it/SbtClientTest.scala
@@ -87,7 +87,8 @@ trait SbtClientTest extends IntegrationTest {
   final def withSbt(projectDirectory: java.io.File)(f: SbtClient => Unit): Unit = {
     // TODO - Create a prop-file locator that uses our own repositories to
     // find the classes, so we use cached values...
-    val connector = new SimpleConnector(projectDirectory, testingLocator(new File(projectDirectory, "../sbt-global")))
+    val connector = new SimpleConnector("sbt-client-test", "SbtClientTest unit test",
+      projectDirectory, testingLocator(new File(projectDirectory, "../sbt-global")))
     // TODO - Executor for this thread....
     object runOneThingExecutor extends concurrent.ExecutionContext {
       private var task = concurrent.promise[Runnable]

--- a/server/src/main/scala/sbt/server/ServerListener.scala
+++ b/server/src/main/scala/sbt/server/ServerListener.scala
@@ -40,6 +40,10 @@ case class JoinedSbtClient(clients: Set[SbtClient]) extends SbtClient {
 }
 // This is what concrete implementations implement.
 abstract class LiveClient extends SbtClient {
+  def uuid: java.util.UUID
+  def configName: String
+  def humanReadableName: String
+
   /** requests a line of input from the client.  This will return sometime in the future. */
   def readLine(replyTo: Long, prompt: String, mask: Boolean): Future[Option[String]]
   /** Confirms a message from a client. */

--- a/terminal/src/main/scala/com/typesafe/sbtrc/client/SimpleSbtTerminal.scala
+++ b/terminal/src/main/scala/com/typesafe/sbtrc/client/SimpleSbtTerminal.scala
@@ -88,7 +88,8 @@ class SimpleSbtTerminal extends xsbti.AppMain {
   case class Exit(code: Int) extends xsbti.Exit
   override def run(configuration: AppConfiguration): xsbti.Exit = {
     System.out.println("Connecting to sbt...")
-    val connector = new SimpleConnector(configuration.baseDirectory, SimpleLocator)
+    val connector = new SimpleConnector("terminal", "Command Line Terminal",
+      configuration.baseDirectory, SimpleLocator)
     (connector onConnect { client =>
       import concurrent.ExecutionContext.global
       // This guy should handle future execution NOT on our event loop, or we'll block.


### PR DESCRIPTION
Several details worth discussing here but patch shows the broad outline.
- uuid, generated client-side so the client has it without an
  extra round trip
- configName, an ID we could use to recognize "the same" client
  and do things like save per-client configuration
- humanReadableName, we might use to display which client
  triggered a certain task or things like that
