### PR TITLE
add SbtClient.requestExecution taking a ScopedKey

### DIFF
--- a/client/src/main/scala/com/typesafe/sbtrc/client/SimpleClient.scala
+++ b/client/src/main/scala/com/typesafe/sbtrc/client/SimpleClient.scala
@@ -46,6 +46,9 @@ class SimpleSbtClient(override val uuid: java.util.UUID,
   def requestExecution(commandOrTask: String, interaction: Option[(Interaction, ExecutionContext)]): Future[Long] = {
     requestHandler.register(client.sendJson(ExecutionRequest(commandOrTask)), interaction).received
   }
+  def requestExecution(key: ScopedKey, interaction: Option[(Interaction, ExecutionContext)]): Future[Long] = {
+    requestHandler.register(client.sendJson(KeyExecutionRequest(key)), interaction).received
+  }
   def handleEvents(listener: EventListener)(implicit ex: ExecutionContext): Subscription =
     eventManager.watch(listener)(ex)
   def watch[T](key: SettingKey[T])(listener: ValueListener[T])(implicit ex: ExecutionContext): Subscription =

--- a/client/src/main/scala/sbt/client/SbtClient.scala
+++ b/client/src/main/scala/sbt/client/SbtClient.scala
@@ -64,9 +64,17 @@ trait SbtClient extends Closeable {
    *
    * @param commandOrTask The full command/task string to run.
    *         that should be evaluated.
-   * @return  A future execution ID, which then appears in execution-related events
+   * @return A future execution ID, which then appears in execution-related events
    */
   def requestExecution(commandOrTask: String, interaction: Option[(Interaction, ExecutionContext)]): Future[Long]
+
+  /**
+   * See the docs for the other variant of requestExecution(). This one takes a key rather than
+   * a string.
+   * @param key key for the task to run
+   * @return A future execution ID, which then appears in execution-related events
+   */
+  def requestExecution(key: ScopedKey, interaction: Option[(Interaction, ExecutionContext)]): Future[Long]
 
   /**
    * Adds a listener to general events which are fired from this sbt server.  These can be things like

--- a/commons/protocol/src/main/scala/sbt/protocol/Protocol.scala
+++ b/commons/protocol/src/main/scala/sbt/protocol/Protocol.scala
@@ -41,6 +41,7 @@ sealed trait Event extends Message
 case class RegisterClientRequest(uuid: String, configName: String, humanReadableName: String) extends Request
 
 case class ExecutionRequest(command: String) extends Request
+case class KeyExecutionRequest(key: ScopedKey) extends Request
 // if the request was combined with an identical pending one,
 // then the id will be the same for the combined requests.
 case class ExecutionRequestReceived(id: Long) extends Response

--- a/commons/protocol/src/main/scala/sbt/protocol/WireProtocol.scala
+++ b/commons/protocol/src/main/scala/sbt/protocol/WireProtocol.scala
@@ -27,6 +27,7 @@ object WireProtocol {
     msg[ReceivedResponse],
     msg[ExecutionRequestReceived],
     msg[ExecutionRequest],
+    msg[KeyExecutionRequest],
     msg[ExecutionStarting],
     msg[ExecutionWaiting],
     msg[ExecutionFailure],

--- a/commons/protocol/src/main/scala/sbt/protocol/package.scala
+++ b/commons/protocol/src/main/scala/sbt/protocol/package.scala
@@ -185,6 +185,7 @@ package object protocol {
   implicit val registerClientRequestFormat = Json.format[RegisterClientRequest]
   implicit val testEventFormat = Json.format[TestEvent]     
   implicit val executionRequestFormat = Json.format[ExecutionRequest]
+  implicit val keyExecutionRequestFormat = Json.format[KeyExecutionRequest]
   implicit val executionReceivedFormat = Json.format[ExecutionRequestReceived]
   implicit val executionWaitingFormat = Json.format[ExecutionWaiting]
   implicit val executionStartingFormat = Json.format[ExecutionStarting]


### PR DESCRIPTION
This way people don't have to build strings on the client.
