### PR TITLE
Do not special-case ExecutionRequest before we have build state

### DIFF
--- a/server/src/main/scala/sbt/server/ReadOnlyServerEngine.scala
+++ b/server/src/main/scala/sbt/server/ReadOnlyServerEngine.scala
@@ -96,8 +96,6 @@ class ReadOnlyServerEngine(
         updateState(_.addEventListener(client))
       case ClientClosedRequest() =>
         updateState(_.disconnect(client))
-      case req: ExecutionRequest =>
-        workRequestsQueue.add(ServerRequest(client, serial, request))
       case _ =>
         // Defer all other messages....
         deferredStartupBuffer.append(ServerRequest(client, serial, request))


### PR DESCRIPTION
The ExecutionRequest handling was copy-pasted in both the
pre-build-state and post-build-state cases. This had two
downsides:
1. code was in two places
2. could result in request reordering during startup

The specific immediate concern here was reordering KeyExecutionRequest
which has to wait on state, vs. ExecutionRequest which does not.
But in general don't think there's any advantage to handling
ExecutionRequest before we have the build state.
