### PR TITLE
Attempt to reply exactly once to all requests

### DIFF
--- a/server/src/main/scala/sbt/server/ServerEngine.scala
+++ b/server/src/main/scala/sbt/server/ServerEngine.scala
@@ -183,8 +183,12 @@ class ServerEngine(requestQueue: ServerEngineQueue, nextStateRef: AtomicReferenc
             }
           }
 
-          import sbt.protocol.executionReceivedFormat
-          request.client.reply(request.serial, ExecutionRequestReceived(id = work.id.id))
+          // serial of 0 means a synthetic request with nobody who cares
+          // about the reply.
+          if (request.serial != 0L) {
+            import sbt.protocol.executionReceivedFormat
+            request.client.reply(request.serial, ExecutionRequestReceived(id = work.id.id))
+          }
 
           workQueue :+ work
         case wtf =>


### PR DESCRIPTION
This allows requesters to block for an "ack" or ErrorResponse if they see
fit. Without the non-error ack, there's no way to know whether an error
is going to arrive later. So this is good general practice to always
have a "yes I got it" reply even if for now we never send back an
error for a particular request.
