### PR TITLE
Fix warnings about unhandled requests

### DIFF
--- a/commons/protocol/src/main/scala/sbt/protocol/Protocol.scala
+++ b/commons/protocol/src/main/scala/sbt/protocol/Protocol.scala
@@ -96,12 +96,7 @@ case class ClientClosedRequest() extends Request
 
 
 case class KeyLookupRequest(name: String) extends Request
-case class KeyLookupResponse(name: String, key: Seq[ScopedKey]) extends Request
-
-case class KeyListRequest(filter: KeyFilter) extends Request
-case class KeyListResponse(keys: KeyList) extends Response
-
-
+case class KeyLookupResponse(name: String, key: Seq[ScopedKey]) extends Response
 
 
 // -----------------------------------------

--- a/server/src/main/scala/sbt/server/ReadOnlyServerEngine.scala
+++ b/server/src/main/scala/sbt/server/ReadOnlyServerEngine.scala
@@ -169,6 +169,10 @@ class ReadOnlyServerEngine(
             c.display,
             c.isEmpty)
         client.send(CommandCompletionsResponse(id, completions.get map convertCompletion))
+      case _: ConfirmRequest | _: ReadLineRequest =>
+        client.reply(serial, ErrorResponse(s"Request ${request.getClass.getName} is intended to go from server to client"))
+      case _: RegisterClientRequest =>
+        client.reply(serial, ErrorResponse("Client can only be registered once, on connection"))
     }
 
 }


### PR DESCRIPTION
- error on the two server-to-client requests
- error on RegisterClientRequest after initial setup
- make KeyLookupResponse extends Response not Request
- delete for-now-unused KeyListRequest, we can always put it back
