### PR TITLE
Add SbtConnector.apply factory method

### DIFF
--- a/client/src/main/scala/sbt/client/SbtConnector.scala
+++ b/client/src/main/scala/sbt/client/SbtConnector.scala
@@ -33,3 +33,19 @@ trait SbtConnector extends Closeable {
    */
   def open(onConnect: SbtClient => Unit, onError: (Boolean, String) => Unit)(implicit ex: ExecutionContext): Subscription
 }
+
+object SbtConnector {
+  /**
+   * Factory method which returns a default SbtConnector. Use open() on the connector
+   * to connect, and close() on the connector to disconnect.
+   *
+   * @param configName an alphanumeric ASCII name used as a config key to track per-client-type state
+   * @param humanReadableName human-readable name of your client used to show in UIs
+   * @param directory the directory to open as an sbt build
+   */
+  def apply(configName: String, humanReadableName: String, directory: java.io.File): SbtConnector = {
+    import com.typesafe.sbtrc.client._
+    new SimpleConnector(configName, humanReadableName, directory,
+      SimpleLocator)
+  }
+}

--- a/terminal/src/main/scala/com/typesafe/sbtrc/client/SimpleSbtTerminal.scala
+++ b/terminal/src/main/scala/com/typesafe/sbtrc/client/SimpleSbtTerminal.scala
@@ -6,6 +6,7 @@ import scala.concurrent.ExecutionContext
 import sbt.client.{
   Interaction,
   SbtClient,
+  SbtConnector,
   RemoteKeys,
   RemoteConfigurations
 }
@@ -96,8 +97,7 @@ class SimpleSbtTerminal extends xsbti.AppMain {
   case class Exit(code: Int) extends xsbti.Exit
   override def run(configuration: AppConfiguration): xsbti.Exit = {
     System.out.println("Connecting to sbt...")
-    val connector = new SimpleConnector("terminal", "Command Line Terminal",
-      configuration.baseDirectory, SimpleLocator)
+    val connector = SbtConnector("terminal", "Command Line Terminal", configuration.baseDirectory)
 
     def onConnect(client: SbtClient): Unit = {
       import concurrent.ExecutionContext.global


### PR DESCRIPTION
This means clients can avoid importing com.typesafe.sbtrc.client
and only import sbt.client, leaving themselves completely
shielded from the implementation classes.
