### PR TITLE
Publish the integration-tests module

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -118,13 +118,16 @@ object TheBuild extends Build {
   // Set up a repository that has all our dependencies.
   import Project.Initialize
 
+  // right now we publish this project because Activator
+  // is using TestUtil; but we should probably clean it
+  // up later so we only publish a test framework
+  // and not the whole thing.
   lazy val itTests: Project = (
     SbtRemoteControlProject("integration-tests")
     dependsOnRemote(sbtLauncherInterface, sbtIo)
     dependsOn(client)
     settings(
-      //com.typesafe.sbtidea.SbtIdeaPlugin.ideaIgnoreModule := true,
-      Keys.publish := {}
+      //com.typesafe.sbtidea.SbtIdeaPlugin.ideaIgnoreModule := true
     )
   )
 


### PR DESCRIPTION
Activator was using the TestUtil class. We should clean
this up so we have a "test framework" lib and then our actual
tests probably, but for now just publish this thing
as we were before.
