### PR TITLE
Send a ClosedEvent when SbtClient closes.

### DIFF
--- a/client/src/main/scala/com/typesafe/sbtrc/client/SimpleClient.scala
+++ b/client/src/main/scala/com/typesafe/sbtrc/client/SimpleClient.scala
@@ -196,7 +196,14 @@ class SimpleSbtClient(override val uuid: java.util.UUID,
         }
       }
       // Here we think sbt connection has closed.
+
+      // make sure it's marked as closed on client side
       client.close()
+
+      // notify
+      eventManager.sendEvent(ClosedEvent())
+
+      // shut 'er down.
       requestHandler.close()
       completionsManager.close()
       keyLookupRequestManager.close()

--- a/commons/protocol/src/main/scala/sbt/protocol/Protocol.scala
+++ b/commons/protocol/src/main/scala/sbt/protocol/Protocol.scala
@@ -104,15 +104,20 @@ case class SendSyntheticValueChanged(key: ScopedKey) extends Request
 // This is issued if a request for a key value fails.
 case class KeyNotFound(key: ScopedKey) extends Response
 
-/** This is a local internal message fired when a client connection is detected
- * to be closed.
+/**
+ * This is fired as an implementation detail on server side when a client connection is detected
+ * to be closed. TODO having this in public API is sort of terrible.
  */
 case class ClientClosedRequest() extends Request
 
+/**
+ * This is synthesized client-side when a client connection closes. It
+ *  purposely has no Format since it doesn't go over the wire.
+ */
+case class ClosedEvent() extends Event
 
 case class KeyLookupRequest(name: String) extends Request
 case class KeyLookupResponse(name: String, key: Seq[ScopedKey]) extends Response
-
 
 // -----------------------------------------
 //                  Events


### PR DESCRIPTION
Previously we had a way to be notified on connector close
but not on SbtClient close, but the natural way to organize
code is to pass just the client to certain modules or objects,
we don't want every piece of code to have to be aware of the
connector. Also it's convenient to just get this in your
event handler and not "out of band."
