### PR TITLE
Include info about requesting client in ExecutionWaiting

### DIFF
--- a/client/src/main/scala/com/typesafe/sbtrc/client/DebugClient.scala
+++ b/client/src/main/scala/com/typesafe/sbtrc/client/DebugClient.scala
@@ -4,6 +4,7 @@ package client
 import java.net._
 import sbt.client._
 import sbt.protocol.RegisterClientRequest
+import sbt.protocol.ClientInfo
 import sbt.protocol.registerClientRequestFormat
 
 object DebugClient {
@@ -12,7 +13,7 @@ object DebugClient {
     val uuid = java.util.UUID.randomUUID()
     val configName = "debug-client"
     val humanReadableName = "Debug Client"
-    client.sendJson(RegisterClientRequest(uuid.toString, configName, humanReadableName))
+    client.sendJson(RegisterClientRequest(ClientInfo(uuid.toString, configName, humanReadableName)))
     new SimpleSbtClient(uuid, configName, humanReadableName, client, closeHandler = () => ())
   }
 }

--- a/client/src/main/scala/com/typesafe/sbtrc/client/SimpleConnector.scala
+++ b/client/src/main/scala/com/typesafe/sbtrc/client/SimpleConnector.scala
@@ -103,7 +103,7 @@ private final class ConnectThread(doneHandler: Try[SbtClient] => Unit,
     val socket = new java.net.Socket(uri.getHost, uri.getPort)
     val rawClient = new ipc.Client(socket)
     val uuid = java.util.UUID.randomUUID()
-    val registerSerial = rawClient.sendJson(RegisterClientRequest(uuid.toString, configName, humanReadableName))
+    val registerSerial = rawClient.sendJson(RegisterClientRequest(ClientInfo(uuid.toString, configName, humanReadableName)))
     Envelope(rawClient.receive()) match {
       case Envelope(_, `registerSerial`, ErrorResponse(message)) =>
         throw new RuntimeException(s"Failed to register client with sbt: ${message}")

--- a/commons/protocol/src/main/scala/sbt/protocol/Protocol.scala
+++ b/commons/protocol/src/main/scala/sbt/protocol/Protocol.scala
@@ -33,12 +33,13 @@ sealed trait Response extends Message
 /** Events that get sent during requests to sbt. */
 sealed trait Event extends Message
 
-
 // ------------------------------------------
 //              Requests (Reactive API)
 // ------------------------------------------
 
-case class RegisterClientRequest(uuid: String, configName: String, humanReadableName: String) extends Request
+case class ClientInfo(uuid: String, configName: String, humanReadableName: String)
+
+case class RegisterClientRequest(info: ClientInfo) extends Request
 
 case class CancelExecutionRequest(id: Long) extends Request
 case class CancelExecutionResponse(attempted: Boolean) extends Response
@@ -49,7 +50,7 @@ case class KeyExecutionRequest(key: ScopedKey) extends Request
 // then the id will be the same for the combined requests.
 case class ExecutionRequestReceived(id: Long) extends Response
 // execution queued up
-case class ExecutionWaiting(id: Long, command: String) extends Event
+case class ExecutionWaiting(id: Long, command: String, client: ClientInfo) extends Event
 // about to execute this one (popped off the queue)
 case class ExecutionStarting(id: Long) extends Event
 // finished executing successfully

--- a/commons/protocol/src/main/scala/sbt/protocol/package.scala
+++ b/commons/protocol/src/main/scala/sbt/protocol/package.scala
@@ -182,8 +182,9 @@ package object protocol {
   }
   implicit val cancelExecutionRequestFormat = Json.format[CancelExecutionRequest]
   implicit val cancelExecutionResponseFormat = Json.format[CancelExecutionResponse]
+  implicit val clientInfoFormat = Json.format[ClientInfo]
   implicit val registerClientRequestFormat = Json.format[RegisterClientRequest]
-  implicit val testEventFormat = Json.format[TestEvent]     
+  implicit val testEventFormat = Json.format[TestEvent]
   implicit val executionRequestFormat = Json.format[ExecutionRequest]
   implicit val keyExecutionRequestFormat = Json.format[KeyExecutionRequest]
   implicit val executionReceivedFormat = Json.format[ExecutionRequestReceived]

--- a/commons/protocol/src/test/scala/ProtocolTest.scala
+++ b/commons/protocol/src/test/scala/ProtocolTest.scala
@@ -63,7 +63,7 @@ class ProtocolTest {
       protocol.ValueChanged(scopedKey, protocol.TaskSuccess(protocol.BuildValue(0.0f))),
       protocol.LogEvent(1, protocol.LogStdOut("Hello, world")),
       protocol.TestEvent(4, "name", None, protocol.TestOutcome("passed"), None),
-      protocol.ExecutionWaiting(41, "foo"),
+      protocol.ExecutionWaiting(41, "foo", protocol.ClientInfo(java.util.UUID.randomUUID.toString, "foo", "FOO")),
       protocol.ExecutionStarting(56),
       protocol.ExecutionFailure(42),
       protocol.ExecutionSuccess(44),

--- a/integration-tests/src/main/scala/com/typesafe/sbtrc/it/execution/TestExecution.scala
+++ b/integration-tests/src/main/scala/com/typesafe/sbtrc/it/execution/TestExecution.scala
@@ -177,8 +177,11 @@ class TestExecution extends SbtClientTest {
         var dep1TaskId = -1L
         verifySequence(recordedDep1.events, Seq(
           {
-            case ExecutionWaiting(id, command) if ((command: String) == "dep1") =>
+            case ExecutionWaiting(id, command, clientInfo) if ((command: String) == "dep1") =>
               executionId = id
+              assert(clientInfo.uuid == client.uuid.toString)
+              assert(clientInfo.configName == client.configName)
+              assert(clientInfo.humanReadableName == client.humanReadableName)
           },
           {
             case ExecutionStarting(id) =>
@@ -226,8 +229,11 @@ class TestExecution extends SbtClientTest {
         var end1TaskId = -1L
         verifySequence(recordedEnd1.events, Seq(
           {
-            case ExecutionWaiting(id, command) if ((command: String) == "end1") =>
+            case ExecutionWaiting(id, command, clientInfo) if ((command: String) == "end1") =>
               executionId = id
+              assert(clientInfo.uuid == client.uuid.toString)
+              assert(clientInfo.configName == client.configName)
+              assert(clientInfo.humanReadableName == client.humanReadableName)
           },
           {
             case ExecutionStarting(id) =>
@@ -277,8 +283,11 @@ class TestExecution extends SbtClientTest {
         var end1TaskId = -1L
         verifySequence(recordedEnd1End2.events, Seq(
           {
-            case ExecutionWaiting(id, command) if ((command: String) == ";end1;end2") =>
+            case ExecutionWaiting(id, command, clientInfo) if ((command: String) == ";end1;end2") =>
               executionId = id
+              assert(clientInfo.uuid == client.uuid.toString)
+              assert(clientInfo.configName == client.configName)
+              assert(clientInfo.humanReadableName == client.humanReadableName)
           },
           {
             case ExecutionStarting(id) =>

--- a/integration-tests/src/main/scala/com/typesafe/sbtrc/it/loading/CanCancelTasks.scala
+++ b/integration-tests/src/main/scala/com/typesafe/sbtrc/it/loading/CanCancelTasks.scala
@@ -36,7 +36,7 @@ class CanCancelTasks extends SbtClientTest {
       val allDone = concurrent.promise[Unit]
       def handleEvent(event: Event): Unit = {
         event match {
-          case ExecutionWaiting(id, "infiniteLoop") => loopIdValue = id
+          case ExecutionWaiting(id, "infiniteLoop", client) => loopIdValue = id
           case ExecutionFailure(id) => if (id == loopIdValue) allDone.success(())
           case _ =>
         }
@@ -101,13 +101,13 @@ class CanCancelTasks extends SbtClientTest {
     verifySequence(events,
       Seq(
         NamedPf("infiniteLoopWaiting", {
-          case ExecutionWaiting(id, command) if ((command: String) == "infiniteLoop") => loopId = id
+          case ExecutionWaiting(id, command, client) if ((command: String) == "infiniteLoop") => loopId = id
         }),
         NamedPf("infiniteLoopStarted", {
           case ExecutionStarting(id) => assert(id == loopId)
         }),
         NamedPf("compileWaiting", {
-          case ExecutionWaiting(id, command) if ((command: String) == "compile") => compileId = id
+          case ExecutionWaiting(id, command, client) if ((command: String) == "compile") => compileId = id
         }),
         NamedPf("compileStarted", {
           case ExecutionStarting(id) => assert(id == compileId)

--- a/server/src/main/scala/com/typesafe/sbtrc/server/SbtServerSocketHandler.scala
+++ b/server/src/main/scala/com/typesafe/sbtrc/server/SbtServerSocketHandler.scala
@@ -48,20 +48,20 @@ class SbtServerSocketHandler(serverSocket: ServerSocket, msgHandler: ServerReque
                 // list. But we aren't really worried about evil/hostile clients just
                 // detecting buggy clients so don't worry about it. Can't happen unless
                 // clients are badly broken (hardcoded fixed uuid?) or malicious.
-                if (clients.exists(_.uuid == req.uuid))
-                  throw replyAndException(s"UUID already in use: ${req.uuid}")
+                if (clients.exists(_.uuid == req.info.uuid))
+                  throw replyAndException(s"UUID already in use: ${req.info.uuid}")
               }
 
-              if (!req.configName.matches("^[-a-zA-Z0-9]+$"))
-                throw replyAndException(s"configName '${req.configName}' must be non-empty and ASCII alphanumeric only")
+              if (!req.info.configName.matches("^[-a-zA-Z0-9]+$"))
+                throw replyAndException(s"configName '${req.info.configName}' must be non-empty and ASCII alphanumeric only")
 
-              if (req.humanReadableName.isEmpty())
+              if (req.info.humanReadableName.isEmpty())
                 throw replyAndException(s"humanReadableName must not be empty")
 
-              try { (java.util.UUID.fromString(req.uuid), req, serial) }
+              try { (java.util.UUID.fromString(req.info.uuid), req.info, serial) }
               catch {
                 case e: IllegalArgumentException =>
-                  throw replyAndException(s"Invalid UUID format: '${req.uuid}'")
+                  throw replyAndException(s"Invalid UUID format: '${req.info.uuid}'")
               }
             case Envelope(serial, _, wtf) =>
               server.replyJson(serial, ErrorResponse("First message must be a RegisterClientRequest"))

--- a/server/src/main/scala/sbt/server/ReadOnlyServerEngine.scala
+++ b/server/src/main/scala/sbt/server/ReadOnlyServerEngine.scala
@@ -121,7 +121,8 @@ class ReadOnlyServerEngine(
               client.reply(serial, ExecutionRequestReceived(id = work.id.id))
               if (isNew) {
                 // If this is a new item in the queue, tell all clients about it.
-                serverState.eventListeners.send(protocol.ExecutionWaiting(work.id.id, work.command))
+                serverState.eventListeners.send(protocol.ExecutionWaiting(work.id.id, work.command,
+                  client.info))
               }
             }
             // Now, we insert the work either at the end, or where it belongs.

--- a/server/src/main/scala/sbt/server/ServerListener.scala
+++ b/server/src/main/scala/sbt/server/ServerListener.scala
@@ -47,6 +47,9 @@ abstract class LiveClient extends SbtClient {
   def configName: String
   def humanReadableName: String
 
+  def info: protocol.ClientInfo =
+    protocol.ClientInfo(uuid = uuid.toString, configName = configName, humanReadableName = humanReadableName)
+
   /** requests a line of input from the client.  This will return sometime in the future. */
   def readLine(executionId: ExecutionId, prompt: String, mask: Boolean): Future[Option[String]]
   /** Confirms a message from a client. */


### PR DESCRIPTION
factor out a ClientInfo blob used here and also in
RegisterClientRequest

@Warry this adds client info to ExecutionWaiting in case you want to know who is causing each task.
