### PR TITLE
Make RequestException do something with its message

### DIFF
--- a/client/src/main/scala/com/typesafe/sbtrc/client/SimpleClient.scala
+++ b/client/src/main/scala/com/typesafe/sbtrc/client/SimpleClient.scala
@@ -301,7 +301,7 @@ class SimpleSbtClient(override val uuid: java.util.UUID,
 
 }
 
-class RequestException(msg: String) extends Exception
+class RequestException(msg: String) extends Exception(msg)
 /** Abstracted mechanism of sending events. */
 trait ListenerType[Event] {
   def send(e: Event): Unit


### PR DESCRIPTION
It was just ignoring the constructor parameter, instead
of putting it in Exception.getMessage
