### PR TITLE
Register reply handlers before sending message we expect reply to

### DIFF
--- a/client/src/main/scala/com/typesafe/sbtrc/client/DebugClient.scala
+++ b/client/src/main/scala/com/typesafe/sbtrc/client/DebugClient.scala
@@ -13,7 +13,8 @@ object DebugClient {
     val uuid = java.util.UUID.randomUUID()
     val configName = "debug-client"
     val humanReadableName = "Debug Client"
-    client.sendJson(RegisterClientRequest(ClientInfo(uuid.toString, configName, humanReadableName)))
+    client.sendJson(RegisterClientRequest(ClientInfo(uuid.toString, configName, humanReadableName)),
+      client.serialGetAndIncrement())
     new SimpleSbtClient(uuid, configName, humanReadableName, client, closeHandler = () => ())
   }
 }

--- a/client/src/main/scala/com/typesafe/sbtrc/client/RequestLifeCycle.scala
+++ b/client/src/main/scala/com/typesafe/sbtrc/client/RequestLifeCycle.scala
@@ -7,7 +7,7 @@ import java.io.Closeable
 
 /** Handles events during a request's lifecycle. */
 private[client] class RequestLifecycle(val serial: Long, val interaction: Interaction) {
-  private val receivedPromise = concurrent.promise[Long]
+  private val receivedPromise = concurrent.Promise[Long]
   val received = receivedPromise.future
   def error(msg: String): Unit =
     receivedPromise.failure(new RequestException(msg))

--- a/client/src/main/scala/com/typesafe/sbtrc/client/SimpleConnector.scala
+++ b/client/src/main/scala/com/typesafe/sbtrc/client/SimpleConnector.scala
@@ -103,7 +103,8 @@ private final class ConnectThread(doneHandler: Try[SbtClient] => Unit,
     val socket = new java.net.Socket(uri.getHost, uri.getPort)
     val rawClient = new ipc.Client(socket)
     val uuid = java.util.UUID.randomUUID()
-    val registerSerial = rawClient.sendJson(RegisterClientRequest(ClientInfo(uuid.toString, configName, humanReadableName)))
+    val registerSerial = rawClient.serialGetAndIncrement()
+    rawClient.sendJson(RegisterClientRequest(ClientInfo(uuid.toString, configName, humanReadableName)), registerSerial)
     Envelope(rawClient.receive()) match {
       case Envelope(_, `registerSerial`, ErrorResponse(message)) =>
         throw new RuntimeException(s"Failed to register client with sbt: ${message}")

--- a/server/src/main/scala/com/typesafe/sbtrc/server/SbtClientHandler.scala
+++ b/server/src/main/scala/com/typesafe/sbtrc/server/SbtClientHandler.scala
@@ -118,9 +118,10 @@ class SbtClientHandler(
     }
     def readLine(executionId: ExecutionId, prompt: String, mask: Boolean): concurrent.Future[Option[String]] =
       synchronized {
-        val result = promise[Option[String]]
-        val newSerial = ipc.sendJson(ReadLineRequest(executionId.id, prompt, mask))
+        val result = Promise[Option[String]]()
+        val newSerial = ipc.serialGetAndIncrement()
         readLineRequests += newSerial -> result
+        ipc.sendJson(ReadLineRequest(executionId.id, prompt, mask), newSerial)
         result.future
       }
     def lineRead(serial: Long, line: Option[String]): Unit =
@@ -135,9 +136,10 @@ class SbtClientHandler(
       }
     def confirm(executionId: ExecutionId, msg: String): concurrent.Future[Boolean] =
       synchronized {
-        val result = promise[Boolean]
-        val newSerial = ipc.sendJson(ConfirmRequest(executionId.id, msg))
+        val result = Promise[Boolean]()
+        val newSerial = ipc.serialGetAndIncrement()
         confirmRequests += newSerial -> result
+        ipc.sendJson(ConfirmRequest(executionId.id, msg), newSerial)
         result.future
       }
 


### PR DESCRIPTION
We sent a message, got serial, then registered reply handler;
we need to generate serial, register reply handler, send message.

Also mixed in are a couple of s/concurrent.promise/concurrent.Promise/
to address deprecation messages.

Also print a complaint on unexpected replies, since that probably
indicates some kind of bug.
