### PR TITLE
Remove deprecated use of concurrent.promise

### DIFF
--- a/integration-tests/src/main/scala/com/typesafe/sbtrc/it/SbtClientTest.scala
+++ b/integration-tests/src/main/scala/com/typesafe/sbtrc/it/SbtClientTest.scala
@@ -18,6 +18,7 @@ import xsbti.{
 import java.nio.charset.Charset.defaultCharset
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import concurrent.Promise
 
 trait SbtClientTest extends IntegrationTest {
   // TODO - load from config - this timeout is long because travis is slow
@@ -99,7 +100,7 @@ trait SbtClientTest extends IntegrationTest {
     val clientCloseLatch = new CountDownLatch(1)
     // TODO - Executor for this thread....
     object runOneThingExecutor extends concurrent.ExecutionContext {
-      private var task = concurrent.promise[Runnable]
+      private var task = Promise[Runnable]
       def execute(runnable: Runnable): Unit = synchronized {
         // We track the number of times our registered connect handler is called here,
         // as we never execute any other future.

--- a/integration-tests/src/main/scala/com/typesafe/sbtrc/it/execution/TestExecution.scala
+++ b/integration-tests/src/main/scala/com/typesafe/sbtrc/it/execution/TestExecution.scala
@@ -5,13 +5,12 @@ package execution
 import sbt.client._
 import sbt.protocol._
 import concurrent.duration.Duration.Inf
-import concurrent.Await
+import concurrent.{ Await, ExecutionContext, Promise }
 import collection.JavaConversions
 import java.io.File
 import java.util.concurrent.LinkedBlockingQueue
 import scala.annotation.tailrec
 import java.util.concurrent.Executors
-import scala.concurrent.ExecutionContext
 
 class TestExecution extends SbtClientTest {
   val dummy = utils.makeDummySbtProject("execution")
@@ -67,7 +66,7 @@ class TestExecution extends SbtClientTest {
     val executorService = Executors.newSingleThreadExecutor()
     implicit val keepEventsInOrderExecutor = ExecutionContext.fromExecutorService(executorService)
     try {
-      val build = concurrent.promise[MinimalBuildStructure]
+      val build = Promise[MinimalBuildStructure]
 
       client watchBuild build.trySuccess
       val result = waitWithError(build.future, "Never got build structure.")

--- a/integration-tests/src/main/scala/com/typesafe/sbtrc/it/loading/CanCancelTasks.scala
+++ b/integration-tests/src/main/scala/com/typesafe/sbtrc/it/loading/CanCancelTasks.scala
@@ -6,7 +6,7 @@ import sbt.client._
 import sbt.protocol._
 import java.util.concurrent.Executors
 import concurrent.duration.Duration.Inf
-import concurrent.{ Await, ExecutionContext }
+import concurrent.{ Await, ExecutionContext, Promise }
 import java.io.File
 import sbt.client.ScopedKey
 import java.util.concurrent.LinkedBlockingQueue
@@ -33,7 +33,7 @@ class CanCancelTasks extends SbtClientTest {
       val results = new LinkedBlockingQueue[(ScopedKey, sbt.client.TaskResult[_])]()
       val events = new LinkedBlockingQueue[Event]()
       var loopIdValue = 0L
-      val allDone = concurrent.promise[Unit]
+      val allDone = Promise[Unit]
       def handleEvent(event: Event): Unit = {
         event match {
           case ExecutionWaiting(id, "infiniteLoop", client) => loopIdValue = id

--- a/integration-tests/src/main/scala/com/typesafe/sbtrc/it/loading/CanUseUiInteractionPlugin.scala
+++ b/integration-tests/src/main/scala/com/typesafe/sbtrc/it/loading/CanUseUiInteractionPlugin.scala
@@ -6,6 +6,7 @@ import sbt.client._
 import sbt.protocol._
 import concurrent.duration.Duration.Inf
 import concurrent.Await
+import concurrent.Promise
 import scala.collection.JavaConverters._
 import play.api.libs.json.Json
 
@@ -78,8 +79,8 @@ class CanUseUiInteractionPlugin extends SbtClientTest {
       }
     }
     val events = new java.util.concurrent.ConcurrentLinkedQueue[Event]
-    val taskResult = concurrent.promise[Boolean]
-    val executionResult = concurrent.promise[Boolean]
+    val taskResult = Promise[Boolean]
+    val executionResult = Promise[Boolean]
     (client handleEvents {
       case TaskFinished(executionId, taskId, key, result) =>
         if (key.map(_.key.name) == Some("readInput")) {
@@ -102,7 +103,7 @@ class CanUseUiInteractionPlugin extends SbtClientTest {
     // Now we try to grab the value of maketestThing 
     // We must explicitly register the mechanism of deserializing the custom message.
     client.dynamicSerialization.register(SerializedThing.format)
-    val testThingValuePromise = concurrent.promise[sbt.protocol.TaskResult[SerializedThing]]
+    val testThingValuePromise = Promise[sbt.protocol.TaskResult[SerializedThing]]
     client.lookupScopedKey("makeTestThing").foreach {
       case Seq(key) =>
         client.watch(TaskKey[SerializedThing](key)) { (key, value) =>

--- a/server/src/main/scala/sbt/server/ServerEngineWork.scala
+++ b/server/src/main/scala/sbt/server/ServerEngineWork.scala
@@ -2,7 +2,7 @@ package sbt
 package server
 
 import sbt.protocol._
-import concurrent.Future
+import concurrent.{ Future, Promise }
 
 final case class ExecutionId(id: Long) {
   require(id != 0L)
@@ -38,7 +38,7 @@ object WorkCancellationStatus {
   /** constructs a new handler for cancel/complete notifications internally. */
   def apply(): WorkCancellationStatus =
     new WorkCancellationStatus {
-      private val completer = concurrent.promise[Unit]
+      private val completer = Promise[Unit]
       override def onCancel(f: () => Unit): Unit =
         completer.future.foreach(_ => f())(SameThreadExecutionContext)
       override def isCancelled: Boolean = completer.isCompleted

--- a/terminal/src/main/scala/com/typesafe/sbtrc/client/SimpleSbtTerminal.scala
+++ b/terminal/src/main/scala/com/typesafe/sbtrc/client/SimpleSbtTerminal.scala
@@ -2,7 +2,7 @@ package com.typesafe.sbtrc
 package client
 
 import xsbti.{ AppMain, AppConfiguration }
-import scala.concurrent.ExecutionContext
+import scala.concurrent.{ ExecutionContext, Promise }
 import sbt.client.{
   Interaction,
   SbtClient,
@@ -64,7 +64,7 @@ class SimpleSbtTerminal extends xsbti.AppMain {
           // Here we wait for the result of both starting (or failure) and the completion of the command.
           val executionFuture = (started flatMap { executionId =>
             // Register for when the execution is done.
-            val executionDone = concurrent.promise[Unit]
+            val executionDone = Promise[Unit]
             // TODO this is broken because we add the event handler
             // AFTER we request execution, which means we might miss
             // the events. We need to add the event handler first


### PR DESCRIPTION
Now only concurrent.Promise is supposed to be used.

We aren't doing imports consistently but tried to match
each individual file. Some future commit can sync
the style across files.
