### PR TITLE
Fix insertWork on execution queue

### DIFF
--- a/server/src/main/scala/sbt/server/ReadOnlyServerEngine.scala
+++ b/server/src/main/scala/sbt/server/ReadOnlyServerEngine.scala
@@ -129,7 +129,7 @@ class ReadOnlyServerEngine(
             def insertWork(remaining: List[ServerEngineWork]): List[ServerEngineWork] =
               remaining match {
                 case hd :: tail if hd.id == work.id => work :: tail
-                case hd :: tail => hd :: insertWork(remaining)
+                case hd :: tail => hd :: insertWork(tail)
                 case Nil => work :: Nil
               }
             workQueue = insertWork(workQueue)


### PR DESCRIPTION
This would stack overflow if the queue had stuff
in it because it put head of the list back on
the entire list rather than back on the tail.
