### PR TITLE
Fix some broken task IDs on stdout/err log events

### DIFF
--- a/server/src/main/scala/sbt/server/TaskProgressShim.scala
+++ b/server/src/main/scala/sbt/server/TaskProgressShim.scala
@@ -80,6 +80,8 @@ private[server] class ServerExecuteProgress(state: ServerState, taskIdRecorder: 
       taskId(task),
       protocolKeyOption(task), result.toEither.isRight))
 
+    taskIdRecorder.unregister(task)
+
     withKeyAndProtocolKey(task) { (key, protocolKey) =>
       // we want to serialize the value only once, iff there's
       // a listener at all...


### PR DESCRIPTION
- flush system buffers whenever we may have changed
  the best guess task ID so we don't have output
  with wrong ID
- unregister IDs when done, so we don't end up
  falling back to an ID that's no longer alive
