### PR TITLE
Don't log an empty string on every stdout/err flush

### DIFF
--- a/server/src/main/scala/sbt/server/SystemShims.scala
+++ b/server/src/main/scala/sbt/server/SystemShims.scala
@@ -12,9 +12,11 @@ private[sbt] class LoggedOutputStream(logger: String => Unit, charset: Charset =
   private val buf = new collection.mutable.ArrayBuffer[Byte]
   override def write(b: Int): Unit = buf.append(b.toByte)
   override def flush(): Unit = {
-    val array = buf.toArray
-    logger(new String(array, charset))
-    buf.clear()
+    if (buf.nonEmpty) {
+      val array = buf.toArray
+      logger(new String(array, charset))
+      buf.clear()
+    }
   }
   // TODO - Do something useful on close...
   override def close(): Unit = {}


### PR DESCRIPTION
This made for a lot of log events with empty strings
in them.
