### PR TITLE
Log the .sbtserver/master.log filename in addition to connections/master...

### DIFF
--- a/server/src/main/scala/com/typesafe/sbtrc/server/SbtServerSocketHandler.scala
+++ b/server/src/main/scala/com/typesafe/sbtrc/server/SbtServerSocketHandler.scala
@@ -13,7 +13,8 @@ import sbt.protocol._
  *
  * TODO - We should use netty for this rather than spawning so many threads.
  */
-class SbtServerSocketHandler(serverSocket: ServerSocket, msgHandler: ServerRequest => Unit) {
+class SbtServerSocketHandler(serverSocket: ServerSocket, msgHandler: ServerRequest => Unit,
+  serverEngineLogFile: java.io.File) {
   private val running = new java.util.concurrent.atomic.AtomicBoolean(true)
   private val TIMEOUT_TO_DEATH: Int = 3 * 60 * 1000
   // TODO - This should be configurable.
@@ -81,7 +82,8 @@ class SbtServerSocketHandler(serverSocket: ServerSocket, msgHandler: ServerReque
           }
           val client = new SbtClientHandler(uuid, register.configName, register.humanReadableName,
             server, msgHandler, onClose)
-          client.send(LogEvent(0L, LogMessage(LogMessage.DEBUG, s"sbt server logs are in: ${log.file.getAbsolutePath}")))
+          client.send(LogEvent(0L, LogMessage(LogMessage.DEBUG, s"sbt server socket logs are in: ${log.file.getAbsolutePath}")))
+          client.send(LogEvent(0L, LogMessage(LogMessage.DEBUG, s"sbt general server logs are in: ${serverEngineLogFile.getAbsolutePath}")))
           clientLock.synchronized {
             clients.append(client)
             log.log(s"Connected Clients: ${clients map (c => s"${c.configName}-${c.uuid}") mkString ", "}")

--- a/server/src/main/scala/sbt/server/ServerEngine.scala
+++ b/server/src/main/scala/sbt/server/ServerEngine.scala
@@ -22,8 +22,11 @@ import scala.concurrent.{ Future, Promise }
  *
  *  @param nextStateRef - We dump the last computed state for read-only processing once it's ready for consumption.
  *  @param queue - The queue we consume server requests from.
+ *  @param serverEngineLogFile - log file to point our file logger at
  */
-class ServerEngine(requestQueue: ServerEngineQueue, nextStateRef: AtomicReference[State]) {
+class ServerEngine(requestQueue: ServerEngineQueue,
+  nextStateRef: AtomicReference[State],
+  serverEngineLogFile: File) {
 
   private val taskIdRecorder = new TaskIdRecorder
   private val eventLogger = new EventLogger(taskIdRecorder)
@@ -103,7 +106,7 @@ class ServerEngine(requestQueue: ServerEngineQueue, nextStateRef: AtomicReferenc
     import CommandStrings.{ BootCommand, DefaultsCommand, InitCommand }
 
     // TODO - can this be part of a command?
-    val globalLogging = initializeLoggers(new File(configuration.baseDirectory, ".sbtserver/master.log"))
+    val globalLogging = initializeLoggers(serverEngineLogFile)
     // TODO - This is copied from StandardMain so we can override globalLogging
     def initialState(configuration: xsbti.AppConfiguration, initialDefinitions: Seq[Command], preCommands: Seq[String]): State =
       {


### PR DESCRIPTION
....log

This required hoisting the filename up out of ServerEngine to SbtServer
so it could be shared. (Should the two "master.log" just be merged?
it would be easy to do building on this patch by sharing the logger
instead of just this filename. But for now just sharing the filename.)
