### PR TITLE
Fixed references for sbt-echo 0.1.1.x -> 0.1.1.3

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -28,7 +28,7 @@ object Dependencies {
 
   // Make sure to update supported versions if Echo plugin version is changed
   val sbtEcho12Version = "0.1.1"
-  val sbtEcho132Version = "0.1.1"
+  val sbtEcho132Version = "0.1.1.3"
   val sbtEcho135Version = "0.1.4"
   val sbt132EchoSupportedAkkaVersion = "2.2.4"
   val sbt132EchoSupportedPlayVersion = "2.2.3"


### PR DESCRIPTION
Bumped legacy version of sbt-echo for sbt 0.13.2
