### PR TITLE
Split RequestListeners apart from ServerState

### DIFF
--- a/server/src/main/scala/sbt/server/BuildStructureCache.scala
+++ b/server/src/main/scala/sbt/server/BuildStructureCache.scala
@@ -14,12 +14,6 @@ object BuildStructureCache {
   def extract(state: State): Option[protocol.MinimalBuildStructure] = state get buildStructureCache
   private def updateImpl(state: State, cache: protocol.MinimalBuildStructure): State = state.put(buildStructureCache, cache)
 
-  def addListener(state: State, listener: SbtClient): State = {
-    val serverState = ServerState.extract(state)
-    sendBuildStructure(listener, SbtDiscovery.buildStructure(state))
-    ServerState.update(state, serverState.addBuildListener(listener))
-  }
-
   def update(state: State): State = {
     val structure = SbtDiscovery.buildStructure(state)
     extract(state) match {

--- a/server/src/main/scala/sbt/server/RequestListeners.scala
+++ b/server/src/main/scala/sbt/server/RequestListeners.scala
@@ -1,0 +1,12 @@
+package sbt
+package server
+
+/**
+ * Represents the current listeners at the time a request is
+ * handed off from ReadOnlyServerEngine to ServerEngine.
+ */
+trait RequestListeners {
+  def buildListeners: SbtClient
+  def keyListeners: Seq[KeyValueClientListener[_]]
+}
+

--- a/server/src/main/scala/sbt/server/ServerEngine.scala
+++ b/server/src/main/scala/sbt/server/ServerEngine.scala
@@ -46,7 +46,9 @@ class ServerEngine(requestQueue: ServerEngineQueue,
 
   final val HandleNextServerRequest = "server-handle-next-server-request"
   final def handleNextRequestCommand = Command.command(HandleNextServerRequest) { state =>
-    val (serverState, work) = requestQueue.blockAndTakeNext
+    val (requestListeners, work) = requestQueue.blockAndTakeNext
+
+    val serverState = ServerState(requestListeners = requestListeners, lastCommand = None)
 
     // here we inject the current serverState into the State object.
     val next = handleWork(work, ServerState.update(state, serverState))

--- a/server/src/main/scala/sbt/server/ServerEngineQueue.scala
+++ b/server/src/main/scala/sbt/server/ServerEngineQueue.scala
@@ -12,5 +12,5 @@ trait ServerEngineQueue {
    * Note:  This will ensure that the work has already been minimized
    *        in the queue before responding.
    */
-  def blockAndTakeNext: (ServerState, ServerEngineWork)
+  def blockAndTakeNext: (RequestListeners, ServerEngineWork)
 }


### PR DESCRIPTION
We had a confusing situation before where ServerState was both
a mutable field in ReadOnlyServerEngine, and attached to State
and modified there between commands. The modifications made
during commands by ServerEngine were never propagated back
to ReadOnlyServerEngine.

This splits it up so that RequestListeners is a mutable field
in ReadOnlyServerEngine which is frozen and handed off to
ServerEngine with each request; and ServerState is only the
extra state that ServerEngine sticks on sbt.State, and is only
modified by changing what's on the sbt.State.
