### PR TITLE
Wip/h3nk3 background run

### DIFF
--- a/client/src/main/scala/com/typesafe/sbtrc/client/SimpleConnector.scala
+++ b/client/src/main/scala/com/typesafe/sbtrc/client/SimpleConnector.scala
@@ -172,7 +172,6 @@ final class SimpleConnector(configName: String, humanReadableName: String, direc
   }
 
   override def open(onConnect: SbtClient => Unit, onError: (Boolean, String) => Unit)(implicit ex: ExecutionContext): Subscription = {
-    println("*** OPEN INITIALIZED: " + new java.util.Date())
     openChannel(channel => onConnect(SbtClient(channel)), onError)(ex)
   }
 
@@ -238,8 +237,6 @@ final class SimpleConnector(configName: String, humanReadableName: String, direc
           case Failure(error) =>
             reconnectOrCloseOnError(error.getMessage)
           case Success(channel) =>
-            println("*** CONNECTED: " + new java.util.Date())
-
             connectState = Open(channel)
             for (listener <- listeners)
               listener.emitConnected(channel)

--- a/ui-interface/src/main/scala/sbt/BackgroundRun.scala
+++ b/ui-interface/src/main/scala/sbt/BackgroundRun.scala
@@ -26,7 +26,7 @@ object SbtBackgroundRunPlugin extends AutoPlugin {
     Keys.runMain <<= runMainTask(),
     Keys.run <<= runTask()))
 
-  private def backgroundRunMainTask(classpath: Initialize[Task[Classpath]], scalaRun: Initialize[Task[ScalaRun]]): Initialize[InputTask[BackgroundJobHandle]] =
+  def backgroundRunMainTask(classpath: Initialize[Task[Classpath]], scalaRun: Initialize[Task[ScalaRun]]): Initialize[InputTask[BackgroundJobHandle]] =
     {
       import DefaultParsers._
       val parser = Defaults.loadForParser(discoveredMainClasses)((s, names) => Defaults.runMainParser(s, names getOrElse Nil))
@@ -38,7 +38,7 @@ object SbtBackgroundRunPlugin extends AutoPlugin {
       }
     }
 
-  private def backgroundRunTask(classpath: Initialize[Task[Classpath]], mainClassTask: Initialize[Task[Option[String]]], scalaRun: Initialize[Task[ScalaRun]]): Initialize[InputTask[BackgroundJobHandle]] =
+  def backgroundRunTask(classpath: Initialize[Task[Classpath]], mainClassTask: Initialize[Task[Option[String]]], scalaRun: Initialize[Task[ScalaRun]]): Initialize[InputTask[BackgroundJobHandle]] =
     {
       import Def.parserToInput
       import sys.error


### PR DESCRIPTION
Makes these two methods public so we can reuse them from other plugins, e.g. sbt-echo.
