### PR TITLE
Remove protocol type aliases from sbt.client

### DIFF
--- a/client/src/main/scala/sbt/client/SbtClient.scala
+++ b/client/src/main/scala/sbt/client/SbtClient.scala
@@ -4,6 +4,7 @@ package client
 import java.io.Closeable
 import concurrent.{ ExecutionContext, Future }
 import play.api.libs.json.Format
+import sbt.protocol._
 
 /**
  * This is the high-level interface for talking to an sbt server; use SbtChannel for the low-level one.

--- a/client/src/main/scala/sbt/client/SettingKey.scala
+++ b/client/src/main/scala/sbt/client/SettingKey.scala
@@ -4,11 +4,11 @@ package client
 import java.net.URI
 
 /** This is a wrapper around scoped keys which you can use to promote typesafe interfaces. */
-final case class SettingKey[T](key: ScopedKey) {
+final case class SettingKey[T](key: protocol.ScopedKey) {
   // TODO - scope changing methods.
 
   def in(build: URI): SettingKey[T] = SettingKey[T](key.copy(scope = key.scope.copy(build = Some(build))))
-  def in(project: ProjectReference): SettingKey[T] =
+  def in(project: protocol.ProjectReference): SettingKey[T] =
     SettingKey[T](key.copy(scope =
       key.scope.copy(
         project = Some(project),

--- a/client/src/main/scala/sbt/client/TaskKey.scala
+++ b/client/src/main/scala/sbt/client/TaskKey.scala
@@ -3,11 +3,11 @@ package sbt.client
 import java.net.URI
 
 /** This is a wrapper around scoped keys which you can use to promote typesafe interfaces. */
-final case class TaskKey[T](key: ScopedKey) {
+final case class TaskKey[T](key: sbt.protocol.ScopedKey) {
   // TODO - scope changing methods.
 
   def in(build: URI): TaskKey[T] = TaskKey[T](key.copy(scope = key.scope.copy(build = Some(build))))
-  def in(project: ProjectReference): TaskKey[T] =
+  def in(project: sbt.protocol.ProjectReference): TaskKey[T] =
 
     TaskKey[T](key.copy(scope =
       key.scope.copy(

--- a/client/src/main/scala/sbt/client/package.scala
+++ b/client/src/main/scala/sbt/client/package.scala
@@ -1,20 +1,8 @@
 package sbt
 
 package object client {
-  // API from the remote protocol directly
-  type KeyFilter = protocol.KeyFilter
-  type ProjectReference = protocol.ProjectReference
-  type ScopedKey = protocol.ScopedKey
-  type TaskResult[+T, +E <: Throwable] = protocol.TaskResult[T, E]
-  type MinimalBuildStructure = protocol.MinimalBuildStructure
-  type Completion = protocol.Completion
-  type ExecutionAnalysis = protocol.ExecutionAnalysis
-
-  // Events from protocol API.
-  type Event = protocol.Event
-
   // Wrapper names for functions
-  type BuildStructureListener = MinimalBuildStructure => Unit
-  type ValueListener[T] = (ScopedKey, TaskResult[T, Throwable]) => Unit
-  type EventListener = Event => Unit
+  type BuildStructureListener = protocol.MinimalBuildStructure => Unit
+  type ValueListener[T] = (protocol.ScopedKey, protocol.TaskResult[T, Throwable]) => Unit
+  type EventListener = protocol.Event => Unit
 }

--- a/integration-tests/src/main/scala/com/typesafe/sbtrc/it/execution/TestExecution.scala
+++ b/integration-tests/src/main/scala/com/typesafe/sbtrc/it/execution/TestExecution.scala
@@ -18,10 +18,10 @@ class TestExecution extends SbtClientTest {
   implicit val keepEventsInOrderExecutor = ExecutionContext.fromExecutorService(executorService)
 
   try {
-    final case class ExecutionRecord(results: Map[ScopedKey, sbt.client.TaskResult[_, Throwable]], events: Seq[Event])
+    final case class ExecutionRecord(results: Map[ScopedKey, TaskResult[_, Throwable]], events: Seq[Event])
 
     def recordExecutions(client: SbtClient, commands: Seq[String]): concurrent.Future[Map[String, ExecutionRecord]] = {
-      val results = new LinkedBlockingQueue[(ScopedKey, sbt.client.TaskResult[_, Throwable])]()
+      val results = new LinkedBlockingQueue[(ScopedKey, TaskResult[_, Throwable])]()
       val events =
         commands.foldLeft(Map.empty[String, LinkedBlockingQueue[Event]]) { (sofar, next) =>
           sofar + (next -> new LinkedBlockingQueue[Event]())
@@ -104,7 +104,7 @@ class TestExecution extends SbtClientTest {
         })
         _ <- concurrent.Future.sequence(executionDones.values.map(_.future)) // wait for complete
       } yield {
-        var resultsMap = Map.empty[ScopedKey, sbt.client.TaskResult[_, Throwable]]
+        var resultsMap = Map.empty[ScopedKey, TaskResult[_, Throwable]]
         while (!results.isEmpty())
           resultsMap += results.take()
 

--- a/integration-tests/src/main/scala/com/typesafe/sbtrc/it/loading/CanCancelTasks.scala
+++ b/integration-tests/src/main/scala/com/typesafe/sbtrc/it/loading/CanCancelTasks.scala
@@ -8,7 +8,6 @@ import java.util.concurrent.Executors
 import concurrent.duration.Duration.Inf
 import concurrent.{ Await, ExecutionContext, Promise }
 import java.io.File
-import sbt.client.ScopedKey
 import java.util.concurrent.LinkedBlockingQueue
 import annotation.tailrec
 
@@ -30,7 +29,7 @@ class CanCancelTasks extends SbtClientTest {
     final case class ExecutionRecord(loopCancelled: Boolean, compileCancelled: Boolean, events: Seq[Event])
 
     def recordExecution(): concurrent.Future[ExecutionRecord] = {
-      val results = new LinkedBlockingQueue[(ScopedKey, sbt.client.TaskResult[_, Throwable])]()
+      val results = new LinkedBlockingQueue[(ScopedKey, TaskResult[_, Throwable])]()
       val events = new LinkedBlockingQueue[Event]()
       var loopIdValue = 0L
       val allDone = Promise[Unit]

--- a/integration-tests/src/main/scala/com/typesafe/sbtrc/it/loading/CanKillServer.scala
+++ b/integration-tests/src/main/scala/com/typesafe/sbtrc/it/loading/CanKillServer.scala
@@ -8,7 +8,6 @@ import java.util.concurrent.Executors
 import concurrent.duration.Duration.Inf
 import concurrent.{ Await, ExecutionContext }
 import java.io.File
-import sbt.client.ScopedKey
 import java.util.concurrent.LinkedBlockingQueue
 import annotation.tailrec
 

--- a/integration-tests/src/main/scala/com/typesafe/sbtrc/it/loading/CanLoadSimpleProject.scala
+++ b/integration-tests/src/main/scala/com/typesafe/sbtrc/it/loading/CanLoadSimpleProject.scala
@@ -9,7 +9,6 @@ import concurrent.Await
 import concurrent.ExecutionContext
 import concurrent.{ Promise, Future }
 import java.io.File
-import sbt.client.ScopedKey
 import java.util.concurrent.Executors
 import java.util.concurrent.LinkedBlockingQueue
 

--- a/terminal/src/main/scala/sbt/terminal/JLineReader.scala
+++ b/terminal/src/main/scala/sbt/terminal/JLineReader.scala
@@ -3,7 +3,7 @@ package terminal
 
 import java.io.File
 import sbt.client.SbtClient
-import sbt.client.Completion
+import sbt.protocol.Completion
 
 // This class blocks on response from the server for autocompletion options.
 final class RemoteJLineReader(


### PR DESCRIPTION
- in some cases (specifying a type parameter for example) these
  don't seem to be interchangeable with the original type
- having two paths to the same type name is confusing for
  API users
- we only had a haphazard subset of sbt.protocol aliased into
  sbt.client anyway
- DRY
