### PR TITLE
Move com.typesafe.sbtrc.client to sbt.client.impl

### DIFF
--- a/client/src/main/scala/sbt/client/SbtClient.scala
+++ b/client/src/main/scala/sbt/client/SbtClient.scala
@@ -210,5 +210,5 @@ object SbtClient {
    *  (TODO right now we require a Format for each serialization, but in fact only the Reads is used.)
    */
   def apply(channel: SbtChannel, serializations: protocol.DynamicSerialization): SbtClient =
-    new com.typesafe.sbtrc.client.SimpleSbtClient(channel, serializations)
+    new impl.SimpleSbtClient(channel, serializations)
 }

--- a/client/src/main/scala/sbt/client/SbtConnector.scala
+++ b/client/src/main/scala/sbt/client/SbtConnector.scala
@@ -48,8 +48,7 @@ object SbtConnector {
    * @param directory the directory to open as an sbt build
    */
   def apply(configName: String, humanReadableName: String, directory: java.io.File): SbtConnector = {
-    import com.typesafe.sbtrc.client._
-    new SimpleConnector(configName, humanReadableName, directory,
-      SimpleLocator)
+    new impl.SimpleConnector(configName, humanReadableName, directory,
+      impl.SimpleLocator)
   }
 }

--- a/client/src/main/scala/sbt/client/impl/DebugClient.scala
+++ b/client/src/main/scala/sbt/client/impl/DebugClient.scala
@@ -1,5 +1,5 @@
-package com.typesafe.sbtrc
-package client
+
+package sbt.client.impl
 
 import sbt.impl.ipc
 import java.net._

--- a/client/src/main/scala/sbt/client/impl/RequestLifeCycle.scala
+++ b/client/src/main/scala/sbt/client/impl/RequestLifeCycle.scala
@@ -1,5 +1,5 @@
-package com.typesafe.sbtrc
-package client
+
+package sbt.client.impl
 
 import sbt.client.Interaction
 import concurrent.ExecutionContext

--- a/client/src/main/scala/sbt/client/impl/SbtServerLocator.scala
+++ b/client/src/main/scala/sbt/client/impl/SbtServerLocator.scala
@@ -1,5 +1,5 @@
-package com.typesafe.sbtrc
-package client
+
+package sbt.client.impl
 
 import java.io.File
 import java.net.{ URI, URL }

--- a/client/src/main/scala/sbt/client/impl/SimpleChannel.scala
+++ b/client/src/main/scala/sbt/client/impl/SimpleChannel.scala
@@ -1,5 +1,5 @@
-package com.typesafe.sbtrc
-package client
+
+package sbt.client.impl
 
 import sbt.impl.ipc
 import sbt.protocol

--- a/client/src/main/scala/sbt/client/impl/SimpleClient.scala
+++ b/client/src/main/scala/sbt/client/impl/SimpleClient.scala
@@ -1,5 +1,5 @@
-package com.typesafe.sbtrc
-package client
+
+package sbt.client.impl
 
 import sbt.protocol
 import sbt.protocol._

--- a/client/src/main/scala/sbt/client/impl/SimpleConnector.scala
+++ b/client/src/main/scala/sbt/client/impl/SimpleConnector.scala
@@ -1,5 +1,5 @@
-package com.typesafe.sbtrc
-package client
+
+package sbt.client.impl
 
 import sbt.impl.ipc
 import sbt.client._

--- a/client/src/main/scala/sbt/client/impl/SimpleLocator.scala
+++ b/client/src/main/scala/sbt/client/impl/SimpleLocator.scala
@@ -1,5 +1,5 @@
-package com.typesafe.sbtrc
-package client
+
+package sbt.client.impl
 
 import java.io.File
 import java.net.URL

--- a/client/src/test/scala/sbt/client/impl/ExecutionContextsTest.scala
+++ b/client/src/test/scala/sbt/client/impl/ExecutionContextsTest.scala
@@ -1,7 +1,7 @@
 /**
  *   Copyright (C) 2014 Typesafe Inc. <http://typesafe.com>
  */
-package com.typesafe.sbtrc.client
+package sbt.client.impl
 
 import org.junit.Assert._
 import org.junit._

--- a/integration-tests/src/main/scala/com/typesafe/sbtrc/it/IntegrationTest.scala
+++ b/integration-tests/src/main/scala/com/typesafe/sbtrc/it/IntegrationTest.scala
@@ -2,7 +2,7 @@ package com.typesafe.sbtrc
 package it
 
 import sbt.client._
-import com.typesafe.sbtrc.client.{
+import sbt.client.impl.{
   SimpleConnector,
   SimpleLocator
 }

--- a/integration-tests/src/main/scala/com/typesafe/sbtrc/it/SbtClientTest.scala
+++ b/integration-tests/src/main/scala/com/typesafe/sbtrc/it/SbtClientTest.scala
@@ -2,7 +2,7 @@ package com.typesafe.sbtrc
 package it
 
 import sbt.client._
-import com.typesafe.sbtrc.client.{
+import sbt.client.impl.{
   SimpleConnector,
   SimpleLocator,
   LaunchedSbtServerLocator


### PR DESCRIPTION
This way it can use private[sbt] stuff and itself be private[sbt](but privatization not done yet, just moving)
