### PR TITLE
Rename ReadOnlyServerEngine to RequestProcessor

### DIFF
--- a/server/src/main/scala/sbt/server/RequestListeners.scala
+++ b/server/src/main/scala/sbt/server/RequestListeners.scala
@@ -3,7 +3,7 @@ package server
 
 /**
  * Represents the current listeners at the time a request is
- * handed off from ReadOnlyServerEngine to ServerEngine.
+ * handed off from RequestProcessor to ServerEngine.
  */
 trait RequestListeners {
   def buildListeners: SbtClient


### PR DESCRIPTION
and nextStateRef to readOnlyStateRef, and clarify some comments.

These classes have evolved over time. The way it works now,
the ServerEngine is the sbt loop, and the request processor
class (now called RequestProcessor) happens to have a read
only copy of the state.

I think this will make it easier for newcomers to the code to
figure out what's going on.
