### PR TITLE
Remove unused RequestCompleted / RequestFailed messages

### DIFF
--- a/commons/protocol/src/main/scala/sbt/protocol/Protocol.scala
+++ b/commons/protocol/src/main/scala/sbt/protocol/Protocol.scala
@@ -257,8 +257,6 @@ final case class ValueChanged(key: ScopedKey, value: TaskResult) extends Event
 final case class ErrorResponse(error: String) extends Response
 /** A notification that a given request has been received. */
 final case class ReceivedResponse() extends Response
-final case class RequestCompleted() extends Response
-final case class RequestFailed() extends Response
 
 final case class ReadLineRequest(executionId: Long, prompt: String, mask: Boolean) extends Request
 final case class ReadLineResponse(line: Option[String]) extends Response

--- a/commons/protocol/src/main/scala/sbt/protocol/WireProtocol.scala
+++ b/commons/protocol/src/main/scala/sbt/protocol/WireProtocol.scala
@@ -24,8 +24,6 @@ private[sbt] object WireProtocol {
     msg[CancelExecutionRequest],
     msg[CancelExecutionResponse],
     msg[RegisterClientRequest],
-    msg[RequestCompleted],
-    msg[RequestFailed],
     msg[ReadLineRequest],
     msg[ReadLineResponse],
     msg[ConfirmRequest],

--- a/commons/protocol/src/main/scala/sbt/protocol/package.scala
+++ b/commons/protocol/src/main/scala/sbt/protocol/package.scala
@@ -219,10 +219,6 @@ package object protocol {
   implicit val receivedResponseReads = emptyObjectReads(ReceivedResponse())
   implicit val receivedResponseWrites = emptyObjectWrites[ReceivedResponse]
 
-  implicit val requestCompletedReads = emptyObjectReads(RequestCompleted())
-  implicit val requestCompletedWrites = emptyObjectWrites[RequestCompleted]
-  implicit val requestFailedReads = emptyObjectReads(RequestFailed())
-  implicit val requestFailedWrites = emptyObjectWrites[RequestFailed]
   implicit val killRequestReads = emptyObjectReads(KillServerRequest())
   implicit val killRequestWrites = emptyObjectWrites[KillServerRequest]
 

--- a/server/src/test/scala/sbt/server/ProtocolTest.scala
+++ b/server/src/test/scala/sbt/server/ProtocolTest.scala
@@ -402,7 +402,6 @@ class ProtocolTest {
       protocol.ConfirmRequest(43, "msg"),
       protocol.ConfirmResponse(true),
       protocol.ReceivedResponse(),
-      protocol.RequestCompleted(),
       protocol.CommandCompletionsRequest("He", 2),
       protocol.CommandCompletionsResponse(Set(protocol.Completion("llo", "Hello", true))),
       protocol.ListenToEvents(),


### PR DESCRIPTION
We are using other success responses, or ErrorResponse, instead.
