### PR TITLE
Include error message in TaskFinished message

### DIFF
--- a/commons/protocol/src/main/scala/sbt/protocol/EventTracker.scala
+++ b/commons/protocol/src/main/scala/sbt/protocol/EventTracker.scala
@@ -71,7 +71,7 @@ private[sbt] object ImpliedState {
         case None =>
           throw new RuntimeException(s"Received TaskStarted for an execution we don't know about")
       }
-    case TaskFinished(executionId, taskId, key, success) =>
+    case TaskFinished(executionId, taskId, key, success, messageOption) =>
       engine.started.get(executionId) match {
         case Some(oldExecution) =>
           if (oldExecution.tasks.contains(taskId)) {
@@ -112,7 +112,8 @@ private[sbt] object ImpliedState {
     TaskStarted(executionId = executionId, taskId = task.id, key = task.key)
 
   private def eventToFinishTask(executionId: Long, task: Task, success: Boolean): EventWithWrites[TaskFinished] =
-    TaskFinished(executionId = executionId, taskId = task.id, key = task.key, success = success)
+    TaskFinished(executionId = executionId, taskId = task.id, key = task.key, success = success,
+      message = if (success) None else Some("Disconnected from sbt"))
 
   private def eventToCreateExecution(execution: Execution): EventWithWrites[ExecutionWaiting] =
     ExecutionWaiting(execution.id, execution.command, execution.client)

--- a/commons/protocol/src/main/scala/sbt/protocol/Protocol.scala
+++ b/commons/protocol/src/main/scala/sbt/protocol/Protocol.scala
@@ -252,8 +252,9 @@ final case class ConfirmResponse(confirmed: Boolean) extends Response
 final case class TaskStarted(executionId: Long, taskId: Long, key: Option[ScopedKey]) extends ExecutionEngineEvent
 // we really could provide taskId ONLY here, but we throw the executionId and key
 // in just for convenience so clients don't have to hash taskId if their
-// only interest is in the key and executionId
-final case class TaskFinished(executionId: Long, taskId: Long, key: Option[ScopedKey], success: Boolean) extends ExecutionEngineEvent
+// only interest is in the key and executionId. Also we include the error
+// message so you can get it even if you don't watch ValueChanged.
+final case class TaskFinished(executionId: Long, taskId: Long, key: Option[ScopedKey], success: Boolean, message: Option[String]) extends ExecutionEngineEvent
 
 final case class BackgroundJobInfo(id: Long, humanReadableName: String, spawningTask: ScopedKey)
 

--- a/commons/protocol/src/test/resource/saved-protocol/0.1/event/task_finished_failed.json
+++ b/commons/protocol/src/test/resource/saved-protocol/0.1/event/task_finished_failed.json
@@ -1,0 +1,1 @@
+{"executionId":48,"taskId":1,"key":{"key":{"name":"name","manifest":{"erasureClass":"java.lang.String","typeArguments":[]}},"scope":{"project":{"build":"file:///test/project","name":"test"}}},"success":false,"message":"error message here","type":"TaskFinished"}

--- a/commons/protocol/src/test/scala/sbt/protocol/EventTrackerTest.scala
+++ b/commons/protocol/src/test/scala/sbt/protocol/EventTrackerTest.scala
@@ -28,7 +28,7 @@ class EventTrackerTest {
       ExecutionStarting(1),
       TaskStarted(1, 1, Some(scopedKey1)),
       TaskStarted(1, 2, Some(scopedKey2)),
-      TaskFinished(1, 1, key = Some(scopedKey1), success = false),
+      TaskFinished(1, 1, key = Some(scopedKey1), success = false, message = Some("Task error message")),
       BackgroundJobStarted(1, BackgroundJobInfo(id = 3, spawningTask = scopedKey2, humanReadableName = "Some job 1")),
       BackgroundJobStarted(1, BackgroundJobInfo(id = 4, spawningTask = scopedKey2, humanReadableName = "Some job 2")),
       ExecutionWaiting(2, "foobar", clientInfo),

--- a/integration-tests/src/main/scala/com/typesafe/sbtrc/it/execution/TestExecution.scala
+++ b/integration-tests/src/main/scala/com/typesafe/sbtrc/it/execution/TestExecution.scala
@@ -83,7 +83,7 @@ class TestExecution extends SbtClientTest {
           case TaskStarted(id, taskId, _) =>
             record(id)
             executionsByTask += (taskId -> id)
-          case TaskFinished(id, taskId, _, _) =>
+          case TaskFinished(id, taskId, _, _, _) =>
             record(id)
             executionsByTask -= taskId
           case TaskLogEvent(taskId, _) =>
@@ -283,7 +283,7 @@ class TestExecution extends SbtClientTest {
               assert(taskId == dep1TaskId)
           },
           {
-            case TaskFinished(id, taskId, Some(key), success) if key.key.name == "dep1" =>
+            case TaskFinished(id, taskId, Some(key), success, _) if key.key.name == "dep1" =>
               assert(id == executionId)
               assert(taskId == dep1TaskId)
               assert(success)
@@ -330,7 +330,7 @@ class TestExecution extends SbtClientTest {
               end1TaskId = taskId
           },
           {
-            case TaskFinished(id, taskId, Some(key), success) if taskId == end1TaskId && key.key.name == "end1" =>
+            case TaskFinished(id, taskId, Some(key), success, _) if taskId == end1TaskId && key.key.name == "end1" =>
               assert(id == executionId)
               assert(taskId == end1TaskId)
               assert(success)
@@ -340,7 +340,7 @@ class TestExecution extends SbtClientTest {
               assert(id == executionId)
           },
           {
-            case TaskFinished(id, _, Some(key), success) if key.key.name == "trigger1" =>
+            case TaskFinished(id, _, Some(key), success, _) if key.key.name == "trigger1" =>
               assert(id == executionId)
           },
           {
@@ -386,7 +386,7 @@ class TestExecution extends SbtClientTest {
               end1TaskId = taskId
           },
           {
-            case TaskFinished(id, taskId, Some(key), success) if taskId == end1TaskId && key.key.name == "end1" =>
+            case TaskFinished(id, taskId, Some(key), success, _) if taskId == end1TaskId && key.key.name == "end1" =>
               assert(id == executionId)
               assert(taskId == end1TaskId)
               assert(success)
@@ -520,7 +520,7 @@ class TestExecution extends SbtClientTest {
                 assert(id == executionId)
             },
             {
-              case TaskFinished(id, taskId, Some(key), success) if key.key.name == name =>
+              case TaskFinished(id, taskId, Some(key), success, _) if key.key.name == name =>
                 assert(id == executionId)
                 assert(success)
             },
@@ -594,9 +594,10 @@ class TestExecution extends SbtClientTest {
                 assert(id == executionId)
             },
             {
-              case TaskFinished(id, taskId, Some(key), success) if key.key.name == name =>
+              case TaskFinished(id, taskId, Some(key), success, messageOption) if key.key.name == name =>
                 assert(id == executionId)
                 assert(!success)
+                assert(messageOption.isDefined)
             },
             {
               case ExecutionFailure(id) =>

--- a/integration-tests/src/main/scala/com/typesafe/sbtrc/it/loading/CanUseUiInteractionPlugin.scala
+++ b/integration-tests/src/main/scala/com/typesafe/sbtrc/it/loading/CanUseUiInteractionPlugin.scala
@@ -82,7 +82,7 @@ class CanUseUiInteractionPlugin extends SbtClientTest {
     val taskResult = Promise[Boolean]
     val executionResult = Promise[Boolean]
     (client handleEvents {
-      case TaskFinished(executionId, taskId, key, result) =>
+      case TaskFinished(executionId, taskId, key, result, messageOption) =>
         if (key.map(_.key.name) == Some("readInput")) {
           taskResult.success(result)
         }

--- a/server/src/test/scala/sbt/server/ProtocolTest.scala
+++ b/server/src/test/scala/sbt/server/ProtocolTest.scala
@@ -418,11 +418,11 @@ class ProtocolTest {
       // Events
       // TODO - CompilationFailure
       protocol.TaskStarted(47, 1, Some(scopedKey)),
-      protocol.TaskFinished(48, 1, Some(scopedKey), true),
+      protocol.TaskFinished(48, 1, Some(scopedKey), true, None),
       protocol.TaskStarted(47, 1, None),
-      protocol.TaskFinished(48, 1, None, true),
+      protocol.TaskFinished(48, 1, None, true, None),
       protocol.TaskStarted(49, 2, Some(scopedKey)),
-      protocol.TaskFinished(50, 2, Some(scopedKey), true),
+      protocol.TaskFinished(50, 2, Some(scopedKey), true, None),
       protocol.BuildStructureChanged(buildStructure),
       // equals() doesn't work on Exception so we can't actually check this easily
       //protocol.ValueChanged(scopedKey, protocol.TaskFailure("O NOES", protocol.BuildValue(new Exception("Exploded"), serializations))),
@@ -604,7 +604,7 @@ class ProtocolTest {
             if (path.exists) sys.error(s"$path exists already")
             else IO.write(path, json.toString, IO.utf8)
           case JsonToObject =>
-            if (!path.exists) { println(s"$path didn't exist, so skipping.") }
+            if (!path.exists) { sys.error(s"$path didn't exist, maybe create with: ${format.writes(t)}.") }
             else {
               val json = Json.parse(IO.read(path, IO.utf8))
               val parsed = addWhatWeWereFormatting(t)(format.reads(json)).asOpt.getOrElse(throw new AssertionError(s"could not re-parse ${json} for ${t}"))
@@ -688,9 +688,10 @@ class ProtocolTest {
 
     // event
     oneWayTrip[Message](protocol.TaskStarted(47, 1, Some(scopedKey))) { _ / "event" / "task_started.json" }
-    oneWayTrip[Message](protocol.TaskFinished(48, 1, Some(scopedKey), true)) { _ / "event" / "task_finished.json" }
+    oneWayTrip[Message](protocol.TaskFinished(48, 1, Some(scopedKey), true, None)) { _ / "event" / "task_finished.json" }
     oneWayTrip[Message](protocol.TaskStarted(47, 1, None)) { _ / "event" / "task_started_none.json" }
-    oneWayTrip[Message](protocol.TaskFinished(48, 1, None, true)) { _ / "event" / "task_finished_none.json" }
+    oneWayTrip[Message](protocol.TaskFinished(48, 1, None, true, None)) { _ / "event" / "task_finished_none.json" }
+    oneWayTrip[Message](protocol.TaskFinished(48, 1, Some(scopedKey), false, Some("error message here"))) { _ / "event" / "task_finished_failed.json" }
     oneWayTrip[Message](protocol.BuildStructureChanged(buildStructure)) { _ / "event" / "build_structure_changed.json" }
     // oneWayTrip[Message](protocol.ValueChanged(scopedKey, protocol.TaskFailure(protocol.BuildValue(new Exception("Exploded"), serializations)))) {
     //   _ / "event" / "value_changed_task_failure.json"


### PR DESCRIPTION
This is to allow clients to easily display why the task
failed, even if they haven't installed a watch on the
task.

A logical question about this is "why not always put the
task result in TaskFinished and get rid of ListenToValue
and ValueChanged?"  ... that may turn out to be the thing
to do, though if any task values are quite large to serialize
it could also be too inefficient. In any case it would be
a much larger refactor than this commit is.
