### PR TITLE
Configure background thread pool so that it resizes

### DIFF
--- a/ui-interface/src/main/scala/sbt/BackgroundRun.scala
+++ b/ui-interface/src/main/scala/sbt/BackgroundRun.scala
@@ -138,7 +138,7 @@ private class BackgroundThreadPool extends java.io.Closeable {
   private val executor = new java.util.concurrent.ThreadPoolExecutor(0, /* corePoolSize */
     32, /* maxPoolSize, max # of bg tasks */
     2, java.util.concurrent.TimeUnit.SECONDS, /* keep alive unused threads this long (if corePoolSize < maxPoolSize) */
-    new java.util.concurrent.LinkedBlockingQueue[Runnable](),
+    new java.util.concurrent.SynchronousQueue[Runnable](),
     threadFactory)
 
   private class BackgroundRunnable(val taskName: String, body: () => Unit)


### PR DESCRIPTION
Currently only one background job will run at a time, with other jobs queued, but given the configuration and comments I'm guessing that this wasn't intended.

Using an unbounded queue means that the thread pool won't grow beyond the specified core size. From the javadoc for ThreadPoolExecutor: "If there are more than corePoolSize but less than maximumPoolSize threads running, a new thread will be created **only if the queue is full**".

Switching to SynchronousQueue (as used by Executors.newCachedThreadPool) means that there's no queueing and gives the behaviour of growing the thread pool up to the maximum, shrinking based on the keep alive timeout, and throws RejectedExecutionException if the maximum is reached.