### PR TITLE
Add type aliases to SPickler and Unpickler

### DIFF
--- a/actor-client/src/test/scala/sbt/client/actors/FakeSbtClient.scala
+++ b/actor-client/src/test/scala/sbt/client/actors/FakeSbtClient.scala
@@ -16,7 +16,6 @@ import akka.pattern.ask
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
-import scala.pickling.Unpickler
 
 final class FakeSubscription[T](refFactory: ActorRefFactory, body: T => Unit, ex: ExecutionContext)(implicit mf: Manifest[T]) extends Subscription {
   private final val enabled = new AtomicBoolean(true)

--- a/client/src/main/scala/sbt/client/SbtClient.scala
+++ b/client/src/main/scala/sbt/client/SbtClient.scala
@@ -5,7 +5,6 @@ import sbt.protocol._
 import sbt.serialization._
 import java.io.Closeable
 import scala.concurrent.{ ExecutionContext, Future }
-import scala.pickling.Unpickler
 
 /**
  * This is the high-level interface for talking to an sbt server; use SbtChannel for the low-level one.

--- a/client/src/main/scala/sbt/client/impl/SimpleClient.scala
+++ b/client/src/main/scala/sbt/client/impl/SimpleClient.scala
@@ -15,7 +15,6 @@ import scala.annotation.tailrec
 import scala.concurrent.{ ExecutionContext, Future, Promise }
 import scala.util.{ Success, Failure, Try }
 import scala.util.control.NonFatal
-import scala.pickling.Unpickler
 
 /**
  * A concrete implementation of the SbtClient trait.

--- a/commons/protocol/src/main/scala/sbt/impl/ipc/IPC.scala
+++ b/commons/protocol/src/main/scala/sbt/impl/ipc/IPC.scala
@@ -12,7 +12,6 @@ import java.io.InputStream
 import java.net.SocketException
 import java.util.concurrent.atomic.AtomicInteger
 import sbt.serialization._
-import scala.pickling.SPickler
 
 trait Envelope[T] {
   def serial: Long

--- a/commons/protocol/src/main/scala/sbt/protocol/EventTracker.scala
+++ b/commons/protocol/src/main/scala/sbt/protocol/EventTracker.scala
@@ -2,7 +2,6 @@ package sbt.protocol
 
 import sbt.serialization._
 import scala.collection.immutable
-import scala.pickling.SPickler
 
 /**
  * Utilities to track the state implied by a series of events, allowing the events

--- a/commons/protocol/src/main/scala/sbt/protocol/Keys.scala
+++ b/commons/protocol/src/main/scala/sbt/protocol/Keys.scala
@@ -3,7 +3,6 @@ package sbt.protocol
 import java.net.URI
 import sbt.serialization._
 import sbt.serialization.functions._
-import scala.pickling.{ SPickler, Unpickler }
 
 /**
  * This represents a "key" in sbt.

--- a/commons/protocol/src/main/scala/sbt/protocol/MessageSerialization.scala
+++ b/commons/protocol/src/main/scala/sbt/protocol/MessageSerialization.scala
@@ -1,7 +1,6 @@
 package sbt.protocol
 
 import sbt.serialization._
-import scala.pickling.{ SPickler, Unpickler }
 
 /**
  * TODO get rid of this object, it just holds one leftover

--- a/commons/protocol/src/main/scala/sbt/protocol/Protocol.scala
+++ b/commons/protocol/src/main/scala/sbt/protocol/Protocol.scala
@@ -3,7 +3,7 @@ package sbt.protocol
 import java.io.File
 import scala.collection.immutable
 import sbt.serialization._
-import scala.pickling.{ directSubclasses, SPickler, Unpickler }
+import scala.pickling.directSubclasses
 import sbt.serialization.functions._
 
 sealed trait CoreProtocol extends CustomPicklers with pickler.SerializationPicklers with SbtSerializers {
@@ -264,14 +264,12 @@ final case class BackgroundJobFinished(executionId: Long, jobId: Long) extends E
 
 final case class TestGroupStarted(name: String)
 object TestGroupStarted extends TaskEventUnapply[TestGroupStarted] {
-  import scala.pickling.{ SPickler, Unpickler }
   import CoreProtocol._
   implicit val pickler: SPickler[TestGroupStarted] = genPickler[TestGroupStarted]
   implicit val unpickler: Unpickler[TestGroupStarted] = genUnpickler[TestGroupStarted]
 }
 final case class TestGroupFinished(name: String, result: TestGroupResult, error: Option[String])
 object TestGroupFinished extends TaskEventUnapply[TestGroupFinished] {
-  import scala.pickling.{ SPickler, Unpickler }
   import CoreProtocol._
   implicit val pickler: SPickler[TestGroupFinished] = genPickler[TestGroupFinished]
   implicit val unpickler: Unpickler[TestGroupFinished] = genUnpickler[TestGroupFinished]
@@ -290,7 +288,7 @@ case object TestGroupError extends TestGroupResult {
   override def toString = "error"
 }
 object TestGroupResult {
-  import scala.pickling.{ SPickler, Unpickler, PicklingException }
+  import scala.pickling.PicklingException
   import CoreProtocol._
   import sbt.serialization.CanToString
 
@@ -319,7 +317,6 @@ final case class TestEvent(name: String, description: Option[String], outcome: T
 }
 
 object TestEvent extends TaskEventUnapply[TestEvent] {
-  import scala.pickling.{ SPickler, Unpickler }
   import CoreProtocol._
   implicit val pickler: SPickler[TestEvent] = genPickler[TestEvent]
   implicit val unpickler: Unpickler[TestEvent] = genUnpickler[TestEvent]
@@ -357,7 +354,7 @@ case object TestSkipped extends TestOutcome {
 }
 
 object TestOutcome {
-  import scala.pickling.{ SPickler, Unpickler, PicklingException }
+  import scala.pickling.PicklingException
   import CoreProtocol._
   import sbt.serialization.CanToString
 
@@ -558,7 +555,7 @@ object Compilations {
 final class CompileFailedException(message: String, cause: Throwable, val problems: Vector[Problem]) extends Exception(message, cause)
 
 object CompileFailedException {
-  import scala.pickling.{ SPickler, Unpickler, FastTypeTag, PBuilder, PReader }
+  import scala.pickling.{ FastTypeTag, PBuilder, PReader }
   import CoreProtocol._
   implicit object picklerUnpickler extends SPickler[CompileFailedException] with Unpickler[CompileFailedException] {
     val tag: FastTypeTag[CompileFailedException] = implicitly[FastTypeTag[CompileFailedException]]
@@ -633,7 +630,7 @@ object ByteArray {
   import CoreProtocol._
   // TODO what a mess, this isn't quite right I'm sure, but probably we just
   // don't need byte arrays anyhow (we don't need all of Analysis)
-  import scala.pickling.{ SPickler, Unpickler, PBuilder, PReader, FastTypeTag, PicklingException }
+  import scala.pickling.{ PBuilder, PReader, FastTypeTag, PicklingException }
   implicit val picklerUnpickler: SPickler[ByteArray] with Unpickler[ByteArray] = new SPickler[ByteArray] with Unpickler[ByteArray] {
     private implicit val arrayPickler = implicitly[SPickler[Array[Byte]]]
     private implicit val arrayUnpickler = implicitly[Unpickler[Array[Byte]]]
@@ -678,8 +675,6 @@ private[sbt] object StructurallyEqual {
 // the macros won't know all the subtypes of Message if we
 // put this companion object earlier in the file.
 object Message {
-
-  import scala.pickling.{ SPickler, Unpickler }
   import CoreProtocol._
 
   // These various picklers are mostly alphabetical except when

--- a/commons/protocol/src/main/scala/sbt/protocol/Values.scala
+++ b/commons/protocol/src/main/scala/sbt/protocol/Values.scala
@@ -2,7 +2,6 @@ package sbt.protocol
 
 import sbt.serialization._, sbt.serialization.functions._
 import scala.util.{ Try, Success, Failure }
-import scala.pickling.{ SPickler, Unpickler }
 
 /**
  *  Represents a serialized value with a stringValue fallback.

--- a/commons/protocol/src/main/scala/sbt/protocol/package.scala
+++ b/commons/protocol/src/main/scala/sbt/protocol/package.scala
@@ -9,7 +9,6 @@ import sbt.serialization.functions._
 package object protocol {
   import CoreProtocol._
   import sbt.serialization.CanToString
-  import scala.pickling.{ SPickler, Unpickler }
 
   //implicit def attributedPickler[T](implicit pickler: SPickler[T]): SPickler[Attributed[T]] = ???
   //implicit def attributedUnpickler[T](implicit unpickler: Unpickler[T]): Unpickler[Attributed[T]] = ???

--- a/commons/protocol/src/test/scala/sbt/protocol/JUnitMessageUtil.scala
+++ b/commons/protocol/src/test/scala/sbt/protocol/JUnitMessageUtil.scala
@@ -3,7 +3,6 @@ package sbt.protocol.spec
 import sbt.protocol.Message
 import org.junit.Assert._
 import org.junit._
-import scala.pickling.{ SPickler, Unpickler }
 import sbt.serialization._
 import scala.pickling.Defaults.pickleOps
 

--- a/commons/protocol/src/test/scala/sbt/protocol/ProtocolSpec.scala
+++ b/commons/protocol/src/test/scala/sbt/protocol/ProtocolSpec.scala
@@ -12,7 +12,7 @@ import JUnitMessageUtil._
 import xsbti.Severity.{ Info, Warn, Error }
 import scala.util.{ Try, Success, Failure }
 import sbt.serialization.json._
-import scala.pickling.{ PickleOps, SPickler, Unpickler }
+import scala.pickling.PickleOps
 import sbt.serialization._
 import scala.pickling.Defaults.pickleOps
 

--- a/commons/ui-interface/src/main/scala/sbt/UI.scala
+++ b/commons/ui-interface/src/main/scala/sbt/UI.scala
@@ -1,7 +1,6 @@
 package sbt
 
 import sbt.serialization._
-import scala.pickling.SPickler
 
 sealed trait InteractionService {
   /** Prompts the user for input, optionally with a mask for characters. */

--- a/integration-tests/src/main/scala/com/typesafe/sbtrc/it/loading/CanUseUiInteractionPlugin.scala
+++ b/integration-tests/src/main/scala/com/typesafe/sbtrc/it/loading/CanUseUiInteractionPlugin.scala
@@ -32,8 +32,8 @@ class CanUseUiInteractionPlugin extends SbtClientTest {
        |  import sbt.serialization._
        |  // TODO - we don't want this to gunky everything up.
        |  import sbt.protocol.CoreProtocol._
-       |  implicit val pickler: scala.pickling.SPickler[SerializedThing] = scala.pickling.Defaults.genPickler[SerializedThing]
-       |  implicit val unpickler: scala.pickling.Unpickler[SerializedThing] = scala.pickling.Defaults.genUnpickler[SerializedThing]
+       |  implicit val pickler: SPickler[SerializedThing] = SPickler.generate[SerializedThing]
+       |  implicit val unpickler: Unpickler[SerializedThing] = Unpickler.generate[SerializedThing]
        |}
        |object TestThingPlugin {
        |   import sbt.protocol.CoreProtocol._  // For SbtSerializer

--- a/integration-tests/src/main/scala/com/typesafe/sbtrc/it/loading/SerializedThing.scala
+++ b/integration-tests/src/main/scala/com/typesafe/sbtrc/it/loading/SerializedThing.scala
@@ -8,6 +8,6 @@ object SerializedThing {
   // TODO - we don't want this to gunky everything up.
   import sbt.protocol.CoreProtocol._
 
-  implicit val pickler: scala.pickling.SPickler[SerializedThing] = scala.pickling.Defaults.genPickler[SerializedThing]
-  implicit val unpickler: scala.pickling.Unpickler[SerializedThing] = scala.pickling.Defaults.genUnpickler[SerializedThing]
+  implicit val pickler: SPickler[SerializedThing] = SPickler.generate[SerializedThing]
+  implicit val unpickler: Unpickler[SerializedThing] = Unpickler.generate[SerializedThing]
 }

--- a/serialization/src/main/scala/sbt/serialization/CustomPicklerUnpickler.scala
+++ b/serialization/src/main/scala/sbt/serialization/CustomPicklerUnpickler.scala
@@ -1,6 +1,5 @@
 package sbt.serialization
 
-import scala.pickling.{ SPickler, Unpickler, FastTypeTag, PBuilder, PReader, PicklingException }
 import sbt.serialization.pickler.{
   PrimitivePicklers,
   PrimitiveArrayPicklers,

--- a/serialization/src/main/scala/sbt/serialization/DebugPickleFormat.scala
+++ b/serialization/src/main/scala/sbt/serialization/DebugPickleFormat.scala
@@ -1,6 +1,14 @@
 package sbt.serialization
 
-import scala.pickling._
+import scala.pickling.{
+  Pickle,
+  PickleFormat,
+  FastTypeTag,
+  PBuilder,
+  PReader,
+  PicklingException,
+  Output
+}
 import scala.reflect.runtime.universe.Mirror
 import scala.util.{ Failure, Success }
 

--- a/serialization/src/main/scala/sbt/serialization/SbtSerializer.scala
+++ b/serialization/src/main/scala/sbt/serialization/SbtSerializer.scala
@@ -1,11 +1,9 @@
 package sbt.serialization
 
-import scala.pickling.{ SPickler, Unpickler }
-
 /**
  * A pair of pickler and unpickler; don't define this by hand, just let
- * it be implicitly created when you define a scala.pickling.SPickler and
- * scala.pickling.Unpickler (or use the default definitions for those).
+ * it be implicitly created when you define a sbt.serialization.SPickler and
+ * sbt.serialization.Unpickler (or use the default definitions for those).
  */
 final class SbtSerializer[T] private[serialization] (val pickler: SPickler[T], val unpickler: Unpickler[T])
 
@@ -16,7 +14,7 @@ object SbtSerializer {
 
 trait SbtSerializers {
   // this is NOT in a companion object to help mandate import
-  // of sbt.serialization._ to get our custom picklers
+  // of sbt.protocol.CoreProtocol._ to get our custom picklers
   implicit def sbtSerializerFromPicklerAndUnpickler[T](implicit pickler: SPickler[T], unpickler: Unpickler[T]): SbtSerializer[T] =
     SbtSerializer[T](pickler, unpickler)
 }

--- a/serialization/src/main/scala/sbt/serialization/SerializationFunctions.scala
+++ b/serialization/src/main/scala/sbt/serialization/SerializationFunctions.scala
@@ -1,6 +1,6 @@
 package sbt.serialization
 
-import scala.pickling.{ SPickler, Unpickler, Generated }
+import scala.pickling.Generated
 
 trait SerializationFunctions {
   import scala.language.experimental.macros

--- a/serialization/src/main/scala/sbt/serialization/SerializedValue.scala
+++ b/serialization/src/main/scala/sbt/serialization/SerializedValue.scala
@@ -2,7 +2,7 @@ package sbt.serialization
 
 import org.json4s.JValue
 import org.json4s.JsonAST._
-import scala.pickling._
+import scala.pickling.PicklingException
 import scala.util.control.NonFatal
 import scala.util.Try
 // Needed for pickle/unpickle methods.

--- a/serialization/src/main/scala/sbt/serialization/json/JSONPickleFormat.scala
+++ b/serialization/src/main/scala/sbt/serialization/json/JSONPickleFormat.scala
@@ -9,9 +9,7 @@ import scala.pickling.{
   PickleFormat,
   PickleTools,
   PicklingException,
-  SPickler,
   StringOutput,
-  Unpickler,
   UnpickleOps
 }
 import scala.pickling.internal.lookupUnpicklee

--- a/serialization/src/main/scala/sbt/serialization/package.scala
+++ b/serialization/src/main/scala/sbt/serialization/package.scala
@@ -1,11 +1,13 @@
 package sbt
 
-import scala.pickling.FastTypeTag
-
 package object serialization {
+  type SPickler[A] = scala.pickling.SPickler[A]
+  val SPickler = scala.pickling.SPickler
+  type Unpickler[A] = scala.pickling.Unpickler[A]
+  val Unpickler = scala.pickling.Unpickler
   val functions: SerializationFunctions = new SerializationFunctions {}
 
   // pickling macros need FastTypeTag$ to have been initialized;
   // if things ever compile with this removed, it can be removed.
-  private val __forceInitializeFastTypeTagCompanion = FastTypeTag
+  private val __forceInitializeFastTypeTagCompanion = scala.pickling.FastTypeTag
 }

--- a/serialization/src/main/scala/sbt/serialization/pickler/CanToString.scala
+++ b/serialization/src/main/scala/sbt/serialization/pickler/CanToString.scala
@@ -3,7 +3,7 @@ package pickler
 
 import java.io.File
 import java.net.URI
-import scala.pickling.{ SPickler, Unpickler, FastTypeTag, PBuilder, PReader, PicklingException }
+import scala.pickling.{ FastTypeTag, PBuilder, PReader, PicklingException }
 
 trait CanToStringPicklers extends PrimitivePicklers {
   implicit def canToStringPickler[A: FastTypeTag](implicit canToString: CanToString[A]): SPickler[A] with Unpickler[A] = new SPickler[A] with Unpickler[A] {

--- a/serialization/src/main/scala/sbt/serialization/pickler/Option.scala
+++ b/serialization/src/main/scala/sbt/serialization/pickler/Option.scala
@@ -1,7 +1,7 @@
 package sbt.serialization
 package pickler
 
-import scala.pickling.{ SPickler, Unpickler, FastTypeTag, PBuilder, PReader, PicklingException }
+import scala.pickling.{ FastTypeTag, PBuilder, PReader, PicklingException }
 
 trait OptionPicklers extends PrimitivePicklers with RichTypes {
   implicit def optionPickler[A: FastTypeTag](implicit elemPickler: SPickler[A], elemUnpickler: Unpickler[A], collTag: FastTypeTag[Option[A]]): SPickler[Option[A]] with Unpickler[Option[A]] =

--- a/serialization/src/main/scala/sbt/serialization/pickler/Primitives.scala
+++ b/serialization/src/main/scala/sbt/serialization/pickler/Primitives.scala
@@ -1,7 +1,7 @@
 package sbt.serialization
 package pickler
 
-import scala.pickling.{ SPickler, Unpickler, FastTypeTag, PBuilder, PReader, PicklingException }
+import scala.pickling.{ FastTypeTag, PBuilder, PReader, PicklingException }
 
 trait PrimitivePicklers {
   implicit val bytePickler: SPickler[Byte] with Unpickler[Byte] = PrimitivePickler[Byte]

--- a/serialization/src/main/scala/sbt/serialization/pickler/Ref.scala
+++ b/serialization/src/main/scala/sbt/serialization/pickler/Ref.scala
@@ -1,7 +1,7 @@
 package sbt.serialization
 package pickler
 
-import scala.pickling.{ SPickler, Unpickler, FastTypeTag, PBuilder, PReader, PicklingException }
+import scala.pickling.{ FastTypeTag, PBuilder, PReader, PicklingException }
 import scala.pickling.refs.Ref
 
 trait RefPicklers {

--- a/serialization/src/main/scala/sbt/serialization/pickler/SerializedValue.scala
+++ b/serialization/src/main/scala/sbt/serialization/pickler/SerializedValue.scala
@@ -1,7 +1,7 @@
 package sbt.serialization
 package pickler
 
-import scala.pickling.{ SPickler, Unpickler, FastTypeTag, PBuilder, PReader }
+import scala.pickling.{ FastTypeTag, PBuilder, PReader }
 import org.json4s.{ JValue, JString }
 
 // TODO comment explaining FakeTags

--- a/serialization/src/main/scala/sbt/serialization/pickler/StringMap.scala
+++ b/serialization/src/main/scala/sbt/serialization/pickler/StringMap.scala
@@ -2,7 +2,7 @@ package sbt.serialization
 package pickler
 
 import scala.collection.generic.CanBuildFrom
-import scala.pickling.{ SPickler, Unpickler, FastTypeTag, PBuilder, PReader, PicklingException }
+import scala.pickling.{ FastTypeTag, PBuilder, PReader, PicklingException }
 
 trait StringMapPicklers {
   // FIXME this could theoretically work for M<:Map[String,A] and use a CanBuildFrom for M?

--- a/serialization/src/main/scala/sbt/serialization/pickler/Throwable.scala
+++ b/serialization/src/main/scala/sbt/serialization/pickler/Throwable.scala
@@ -1,7 +1,7 @@
 package sbt.serialization
 package pickler
 
-import scala.pickling.{ SPickler, Unpickler, FastTypeTag, PBuilder, PReader, PicklingException }
+import scala.pickling.{ FastTypeTag, PBuilder, PReader, PicklingException }
 import scala.pickling.static._
 
 private[pickler] final case class StackTraceElementDeserialized(declaringClass: String,

--- a/serialization/src/main/scala/sbt/serialization/pickler/Traversable.scala
+++ b/serialization/src/main/scala/sbt/serialization/pickler/Traversable.scala
@@ -2,7 +2,7 @@ package sbt.serialization
 package pickler
 
 import scala.collection.generic.CanBuildFrom
-import scala.pickling.{ SPickler, Unpickler, FastTypeTag, PBuilder, PReader, PicklingException }
+import scala.pickling.{ FastTypeTag, PBuilder, PReader, PicklingException }
 
 trait VectorPicklers {
   implicit def vectorPickler[T: FastTypeTag](implicit elemPickler: SPickler[T], elemUnpickler: Unpickler[T], collTag: FastTypeTag[Vector[T]], cbf: CanBuildFrom[Vector[T], T, Vector[T]]): SPickler[Vector[T]] with Unpickler[Vector[T]] =

--- a/serialization/src/test/scala/sbt/serialization/ArrayPicklerSpec.scala
+++ b/serialization/src/test/scala/sbt/serialization/ArrayPicklerSpec.scala
@@ -4,7 +4,7 @@ import org.junit.Assert._
 import org.junit._
 import java.io.File
 import java.net.URI
-import scala.pickling.{ PickleOps, UnpickleOps, SPickler, Unpickler, FastTypeTag }
+import scala.pickling.{ PickleOps, UnpickleOps, FastTypeTag }
 import JUnitUtil._
 import scala.pickling.Defaults.pickleOps
 import sbt.serialization._, sbt.serialization.json._

--- a/serialization/src/test/scala/sbt/serialization/JUnitUtil.scala
+++ b/serialization/src/test/scala/sbt/serialization/JUnitUtil.scala
@@ -2,7 +2,6 @@ package sbt.serialization.spec
 
 import org.junit.Assert._
 import org.junit._
-import scala.pickling.{ SPickler, Unpickler }
 import sbt.serialization._
 import scala.pickling.Defaults.pickleOps
 

--- a/server/src/main/scala/sbt/server/UIShim.scala
+++ b/server/src/main/scala/sbt/server/UIShim.scala
@@ -11,7 +11,6 @@ import sbt.protocol.CoreLogEvent
 import sbt.protocol.LogMessage
 import sbt.protocol.BackgroundJobInfo
 import sbt.serialization._
-import scala.pickling.SPickler
 
 private[server] class ServerInteractionService(state: ServerState) extends SbtPrivateInteractionService {
 

--- a/server/src/test/scala/sbt/server/ProtocolTest.scala
+++ b/server/src/test/scala/sbt/server/ProtocolTest.scala
@@ -373,7 +373,6 @@ object ProtocolGenerators {
 
 final case class PlayStartedEvent(port: Int)
 object PlayStartedEvent extends protocol.TaskEventUnapply[PlayStartedEvent] {
-  import scala.pickling.{ SPickler, Unpickler }
   implicit val pickler = genPickler[PlayStartedEvent]
   implicit val unpickler = genUnpickler[PlayStartedEvent]
 }

--- a/ui-interface/src/main/scala/sbt/Plugin.scala
+++ b/ui-interface/src/main/scala/sbt/Plugin.scala
@@ -3,7 +3,6 @@ package sbt
 import sbt.ScopeAxis.scopeAxisToScope
 import std.TaskStreams
 import sbt.serialization._
-import scala.pickling.SPickler
 
 /**
  * This UI plugin provides the basic settings used by plugins that want to be able to communicate with a UI.


### PR DESCRIPTION
The primary change is

```scala
 package object serialization {
+  type SPickler[A] = scala.pickling.SPickler[A]
+  val SPickler = scala.pickling.SPickler
+  type Unpickler[A] = scala.pickling.Unpickler[A]
+  val Unpickler = scala.pickling.Unpickler
```
