### PR TITLE
Wip/fix serialized value

### DIFF
--- a/commons/protocol/src/main/scala/sbt/impl/ipc/IPC.scala
+++ b/commons/protocol/src/main/scala/sbt/impl/ipc/IPC.scala
@@ -113,7 +113,8 @@ abstract class Peer(protected val socket: Socket) {
   }
 
   private def jsonString[T: SPickler](message: T): String = {
-    JsonValue(message).renderCompact
+    // TODO - move this to SerializedValue, perhaps
+    JsonValue(message).toJsonString
   }
 
   def sendJson[T: SPickler](message: T, serial: Long): Unit = {

--- a/commons/protocol/src/main/scala/sbt/protocol/Values.scala
+++ b/commons/protocol/src/main/scala/sbt/protocol/Values.scala
@@ -8,8 +8,8 @@ import scala.pickling.{ SPickler, Unpickler }
  *  Represents a serialized value with a stringValue fallback.
  */
 final case class BuildValue(serialized: SerializedValue, stringValue: String) {
-  def value[T](implicit unpickler: Unpickler[T]): Option[T] =
-    serialized.parse[T].toOption
+  def value[T](implicit unpickler: Unpickler[T]): Try[T] =
+    serialized.parse[T]
   override def equals(o: Any): Boolean =
     o match {
       case x: BuildValue => x.serialized == serialized
@@ -66,14 +66,14 @@ final case class TaskSuccess(value: BuildValue) extends TaskResult {
   override def isSuccess = true
   override def resultWithCustomThrowable[A, B <: Throwable](implicit unpickleResult: Unpickler[A], unpickleFailure: Unpickler[B]): Try[A] = {
     value.value[A] match {
-      case Some(v) => Success(v)
-      case None => Failure(new Exception(s"Failed to deserialize ${value.serialized}"))
+      case Success(v) => Success(v)
+      case Failure(t) => Failure(new Exception(s"Failed to deserialize ${value.serialized}", t))
     }
   }
   override def resultWithCustomThrowables[A](throwableDeserializers: ThrowableDeserializers)(implicit unpickleResult: Unpickler[A]): Try[A] = {
     value.value[A] match {
-      case Some(v) => Success(v)
-      case None => Failure(new Exception(s"Failed to deserialize ${value.serialized}"))
+      case Success(v) => Success(v)
+      case Failure(t) => Failure(new Exception(s"Failed to deserialize ${value.serialized}", t))
     }
   }
 }

--- a/commons/protocol/src/main/scala/sbt/protocol/Values.scala
+++ b/commons/protocol/src/main/scala/sbt/protocol/Values.scala
@@ -64,18 +64,10 @@ sealed trait TaskResult {
 /** This represents that the task was run successfully. */
 final case class TaskSuccess(value: BuildValue) extends TaskResult {
   override def isSuccess = true
-  override def resultWithCustomThrowable[A, B <: Throwable](implicit unpickleResult: Unpickler[A], unpickleFailure: Unpickler[B]): Try[A] = {
-    value.value[A] match {
-      case Success(v) => Success(v)
-      case Failure(t) => Failure(new Exception(s"Failed to deserialize ${value.serialized}", t))
-    }
-  }
-  override def resultWithCustomThrowables[A](throwableDeserializers: ThrowableDeserializers)(implicit unpickleResult: Unpickler[A]): Try[A] = {
-    value.value[A] match {
-      case Success(v) => Success(v)
-      case Failure(t) => Failure(new Exception(s"Failed to deserialize ${value.serialized}", t))
-    }
-  }
+  override def resultWithCustomThrowable[A, B <: Throwable](implicit unpickleResult: Unpickler[A], unpickleFailure: Unpickler[B]): Try[A] =
+    value.value[A]
+  override def resultWithCustomThrowables[A](throwableDeserializers: ThrowableDeserializers)(implicit unpickleResult: Unpickler[A]): Try[A] =
+    value.value[A]
 }
 
 final case class TaskFailure(cause: BuildValue) extends TaskResult {

--- a/commons/protocol/src/main/scala/sbt/protocol/WireProtocol.scala
+++ b/commons/protocol/src/main/scala/sbt/protocol/WireProtocol.scala
@@ -16,7 +16,7 @@ private[sbt] object Envelope {
   def apply(wire: ipc.WireEnvelope): Envelope = {
     //System.err.println(s"Attempting to parse ${wire.asString}")
     val message: Message =
-      JsonValue.parseJson(wire.asString).flatMap(_.parse[Message]).recover({
+      SerializedValue.fromJsonString(wire.asString).parse[Message].recover({
         case NonFatal(e) =>
           try System.err.println(s"Failed to parse message ${wire.asString}: ${e.getClass.getName}: ${e.getMessage}") catch { case _: Throwable => }
           ErrorResponse(s"exception parsing json: ${e.getMessage}")

--- a/integration-tests/src/main/scala/com/typesafe/sbtrc/it/execution/TestExecution.scala
+++ b/integration-tests/src/main/scala/com/typesafe/sbtrc/it/execution/TestExecution.scala
@@ -167,7 +167,7 @@ class TestExecution extends SbtClientTest {
         case (key, result) if key.key.name == taskName =>
           result
       }).headOption match {
-        case Some(TaskSuccess(value)) if (value.value[T] == Some(expected)) => // ok!
+        case Some(TaskSuccess(value)) if (value.value[T] == util.Success(expected)) => // ok!
         case Some(TaskSuccess(value)) =>
           throw new AssertionError(s"Value of ${taskName} was was ${value}, expected Some(${expected})")
         case wrong =>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -52,7 +52,7 @@ object Dependencies {
   val pickling = "org.scala-lang.modules" %% "scala-pickling" % picklingVersion
 
   private val jsonTuples = Seq(
-    ("org.json4s", "json4s-native", "3.2.10"),
+    ("org.json4s", "json4s-core", "3.2.10"),
     ("org.spire-math", "jawn-parser", "0.6.0"),
     ("org.spire-math", "json4s-support", "0.6.0")
   )

--- a/serialization/src/main/scala/sbt/serialization/SerializedValue.scala
+++ b/serialization/src/main/scala/sbt/serialization/SerializedValue.scala
@@ -7,6 +7,9 @@ import scala.util.control.NonFatal
 import scala.util.Try
 // Needed for pickle/unpickle methods.
 import scala.pickling.functions._
+import sbt.serialization.json.{
+  JSONPickle
+}
 
 /**
  * We serialize to and from this opaque type. The idea is to
@@ -20,72 +23,59 @@ sealed trait SerializedValue {
 object SerializedValue {
   def apply[V](value: V)(implicit pickler: SPickler[V]): SerializedValue =
     JsonValue[V](value)(pickler)
+
+  /** Reconstitutes a SerialziedValue from a json string. */
+  def fromJsonString(value: String): SerializedValue =
+    JsonValue.fromJsonString(value)
+  /** Reconstitutes a SerialziedValue from a json AST. */
+  def fromJsonAST(value: JValue): SerializedValue =
+    JsonValue.fromJValue(value)
+
 }
 
+// TODO - If this is meant to handle any kind of pickle format, it needs
+//        to encode the pickle format directly.
+//        i.e. it'd be nice if we had some kind of class that had a PickleFormat and Pickle
+//        if we ever wanted to support alternative SerializedValues.
 private[sbt] sealed trait SbtPrivateSerializedValue extends SerializedValue {
+  /**
+   * Returns this serialized value pickled into a json Tree.
+   *
+   * Note: This may be an expensive operation.
+   */
   def toJson: JsonValue
+  /**
+   * Returns the serialzied value as a raw JSON string.
+   *
+   * Note: this may be an expensive operation.
+   */
+  def toJsonString: String
 }
 
+import sbt.serialization.json.JsonMethods._
 /** A value we have serialized as JSON */
-private[sbt] final case class JsonValue(json: JValue) extends SbtPrivateSerializedValue {
-  override def parse[T](implicit unpicklerForT: Unpickler[T]): Try[T] = {
-    import sbt.serialization.json.pickleFormat
-    import sbt.serialization.json.JSONPickle
-    import org.json4s.native.JsonMethods._
-    // TODO don't convert the AST to a string before parsing it!
-    Try { unpickle[T](JSONPickle(compact(render(json)))) }
-  }
+private[sbt] final case class JsonValue(pickledValue: JSONPickle) extends SbtPrivateSerializedValue {
+  import sbt.serialization.json.pickleFormat
+  override def parse[T](implicit unpicklerForT: Unpickler[T]): Try[T] =
+    Try { unpickle[T](pickledValue) }
+
   override def toJson = this
-
-  def renderCompact: String = {
-    import org.json4s.native.JsonMethods._
-    compact(render(json))
-  }
-
-  def renderPretty: String = {
-    import org.json4s.native.JsonMethods._
-    pretty(render(json))
-  }
-
+  override def toJsonString: String = pickledValue.value
   override def equals(other: Any): Boolean =
     other match {
-      case JsonValue(oj) => jvalueEquals(json, oj)
+      case JsonValue(pv) => pickledValue == pv
       case _ => false
     }
-
-  private def jvalueEquals(jvalue: JValue, jvalue2: JValue): Boolean =
-    (jvalue, jvalue2) match {
-      case (JNull, null) | (null, JNull) | (JNull, JNull) | (null, null) => true
-      case (JNothing, JNothing) => true
-      case (JBool(v), JBool(v2)) => v == v2
-      case (JDouble(v), JDouble(v2)) => v == v2
-      case (JString(v), JString(v2)) => v == v2
-      case (JArray(el), JArray(el2)) => (el.size == el2.size) && (el.zip(el2).forall((jvalueEquals _).tupled))
-      case (JObject(el), JObject(el2)) =>
-        (el.size == el2.size) && (
-          el.sortBy(_._1).zip(el2.sortBy(_._1)).forall {
-            case ((k, v), (k2, v2)) => (k == k2) && jvalueEquals(v, v2)
-          })
-      case (left, right) =>
-        System.err.println("Found differences between [$left] and [$right]")
-        false
-    }
-
-  override def toString = renderCompact
+  override def toString = toJsonString
 }
 
 private[sbt] object JsonValue {
-  private def parseJValue(s: String): Try[JValue] = {
-    jawn.support.json4s.Parser.parseFromString(s) recover {
-      case e @ jawn.ParseException(msg, _, line, col) =>
-        throw PicklingException(s"Parse error line $line column $col '$msg' in $s", Some(e))
-      case e @ jawn.IncompleteParseException(msg) =>
-        throw PicklingException(s"Incomplete json '$msg' in $s", Some(e))
-    }
-  }
 
-  private[sbt] def parseJson(s: String): Try[JsonValue] =
-    parseJValue(s) map { json => new JsonValue(json) }
+  private[sbt] def fromJsonString(s: String): JsonValue =
+    new JsonValue(JSONPickle(s))
+
+  private[sbt] def fromJValue(jv: JValue): JsonValue =
+    new JsonValue(JSONPickle.fromJValue(jv))
 
   // this is sort of dangerous because if you call it on a String
   // expecting to get the parseJson scenario above, you won't
@@ -93,10 +83,10 @@ private[sbt] object JsonValue {
   def apply[T](t: T)(implicit picklerForT: SPickler[T]): JsonValue = {
     import sbt.serialization.json.pickleFormat
     // TODO don't stringify the AST and then re-parse it!
-    parseJson(pickle(t).value).get
+    JsonValue(pickle(t))
   }
 
-  val emptyObject = JsonValue(org.json4s.JObject(Nil))
+  val emptyObject = JsonValue.fromJValue(org.json4s.JObject(Nil))
 }
 
 /**

--- a/serialization/src/main/scala/sbt/serialization/SerializedValue.scala
+++ b/serialization/src/main/scala/sbt/serialization/SerializedValue.scala
@@ -15,9 +15,14 @@ import sbt.serialization.json.{
  * We serialize to and from this opaque type. The idea is to
  * hide exactly what we can serialize from/to and hide
  * which library we use to do it.
+ *
+ * What this will expose is the mechanism of using Pickler/Unpickler to
+ * handle unknown serialized values.
  */
 sealed trait SerializedValue {
   def parse[T](implicit unpickler: Unpickler[T]): Try[T]
+
+  // TODO - expose toJson, toBinary etc. (anyhting we need).
 }
 
 object SerializedValue {
@@ -27,10 +32,9 @@ object SerializedValue {
   /** Reconstitutes a SerialziedValue from a json string. */
   def fromJsonString(value: String): SerializedValue =
     JsonValue.fromJsonString(value)
-  /** Reconstitutes a SerialziedValue from a json AST. */
-  def fromJsonAST(value: JValue): SerializedValue =
-    JsonValue.fromJValue(value)
 
+
+  // TODO - Expose fromBinaryBlob if/when we support binary.
 }
 
 // TODO - If this is meant to handle any kind of pickle format, it needs

--- a/serialization/src/main/scala/sbt/serialization/json/JSONPickleFormat.scala
+++ b/serialization/src/main/scala/sbt/serialization/json/JSONPickleFormat.scala
@@ -154,7 +154,7 @@ package json {
           else if (primitiveArrays.contains(hints.tag.key)) {
             primitiveArrays(hints.tag.key)(picklee)
           } else if (isJValue(hints.tag)) {
-            import org.json4s.native.JsonMethods._
+            import JsonMethods._
             buf.put(compact(render(picklee.asInstanceOf[JValue])))
           } else {
             // Note: It's possible the object is empty, so we just put an empty object here,

--- a/serialization/src/main/scala/sbt/serialization/json/JsonMethods.scala
+++ b/serialization/src/main/scala/sbt/serialization/json/JsonMethods.scala
@@ -1,0 +1,126 @@
+package sbt.serialization.json
+
+import org.json4s.{
+  JsonInput,
+  StringInput,
+  StreamInput,
+  ReaderInput,
+  FileInput,
+  JValue,
+  JField,
+  JNothing,
+  JBool,
+  JString,
+  JInt,
+  JDecimal,
+  JArray,
+  JObject,
+  JNull,
+  JDouble
+}
+import java.io.File
+import scala.pickling.PicklingException
+import scala.util.Try
+
+/** An implementation of JsonMethods for json4s that uses Jawn and our own toStrings. */
+object JsonMethods extends org.json4s.JsonMethods[JValue] {
+  // Redner doesn't do anything, as we aren't translating to an intermediate format before rendering.
+  override def render(value: JValue): JValue = value
+  // TODO - Write this.
+  override def pretty(d: JValue): String = compact(d)
+  // Compact rendering.
+  override def compact(d: JValue): String = {
+    val buf = new StringBuilder("")
+    import org.json4s._
+    def trimArr(xs: List[JValue]) = xs.filter(_ != JNothing)
+    def trimObj(xs: List[JField]) = xs.filter(_._2 != JNothing)
+    def append(d: JValue): Unit = {
+      d match {
+        case null => buf.append("null")
+        case JBool(true) => buf.append("true")
+        case JBool(false) => buf.append("false")
+        case JDouble(n) => buf.append(n.toString)
+        case JDecimal(n) => buf.append(n.toString)
+        case JInt(n) => buf.append(n.toString)
+        case JNull => buf.append("null")
+        // TODO - better error message
+        case JNothing => sys.error("can't render 'nothing'")
+        // TODO - does this even make sense?
+        case JString(null) => buf.append("null")
+        case JString(s) =>
+          buf.append("\"")
+          buf.append(ParserUtil.quote(s))
+          buf.append("\"")
+        case JArray(arr) =>
+          buf.append("[")
+          val trimmed = trimArr(arr)
+          var l = trimmed
+          while (!l.isEmpty) {
+            val el = l.head
+            if (l ne trimmed) buf.append(",")
+            append(el)
+            l = l.tail
+          }
+          buf.append("]")
+        case JObject(obj) =>
+          buf.append("{")
+          val trimmed = trimObj(obj)
+          var l = trimmed
+          while (!l.isEmpty) {
+            val (k, v) = l.head
+            if (l ne trimmed) buf.append(",")
+            buf.append("\"").append(ParserUtil.quote(k)).append("\":")
+            append(v)
+            l = l.tail
+          }
+          buf.append("}")
+      }
+    }
+    append(d)
+    buf.toString
+  }
+
+  override def parse(in: JsonInput, useBigDecimalForDouble: Boolean): JValue =
+    parseTry(in, useBigDecimalForDouble).get
+  override def parseOpt(in: JsonInput, useBigDecimalForDouble: Boolean): Option[JValue] =
+    parseTry(in, useBigDecimalForDouble).toOption
+  def parseTry(in: JsonInput, useBigDecimalForDouble: Boolean): Try[JValue] = {
+    val result: Try[JValue] = in match {
+      case StringInput(string) => jawn.support.json4s.Parser.parseFromString(string)
+      // TODO - We should support the reader case too.
+      case ReaderInput(reader) => util.Try(???)
+      case StreamInput(stream) =>
+        val in = java.nio.channels.Channels.newChannel(stream)
+        try jawn.support.json4s.Parser.parseFromChannel(in)
+        finally in.close()
+      case FileInput(file: File) =>
+        val in = (new java.io.FileInputStream(file)).getChannel
+        try jawn.support.json4s.Parser.parseFromChannel(in)
+        finally in.close()
+    }
+    result recover {
+      case e @ jawn.ParseException(msg, _, line, col) =>
+        throw PicklingException(s"Parse error line $line column $col '$msg' in $in", Some(e))
+      case e @ jawn.IncompleteParseException(msg) =>
+        throw PicklingException(s"Incomplete json '$msg' in $in", Some(e))
+    }
+  }
+
+  final def jvalueEquals(jvalue: JValue, jvalue2: JValue): Boolean =
+    (jvalue, jvalue2) match {
+      case (JNull, null) | (null, JNull) | (JNull, JNull) | (null, null) => true
+      case (JNothing, JNothing) => true
+      case (JBool(v), JBool(v2)) => v == v2
+      case (JDouble(v), JDouble(v2)) => v == v2
+      case (JString(v), JString(v2)) => v == v2
+      case (JArray(el), JArray(el2)) => (el.size == el2.size) && (el.zip(el2).forall((jvalueEquals _).tupled))
+      case (JObject(el), JObject(el2)) =>
+        (el.size == el2.size) && (
+          el.sortBy(_._1).zip(el2.sortBy(_._1)).forall {
+            case ((k, v), (k2, v2)) => (k == k2) && jvalueEquals(v, v2)
+          })
+      case (left, right) =>
+        System.err.println("Found differences between [$left] and [$right]")
+        false
+    }
+}

--- a/serialization/src/test/scala/sbt/serialization/JUnitUtil.scala
+++ b/serialization/src/test/scala/sbt/serialization/JUnitUtil.scala
@@ -71,5 +71,5 @@ object JUnitUtil {
   import sbt.serialization.json.JSONPickle
   import scala.pickling.UnpickleOps
   implicit def toJSONPickle(value: String): JSONPickle = JSONPickle(value)
-  implicit def toUnpickleOps(value: String): UnpickleOps = new UnpickleOps(new JSONPickle(value))
+  implicit def toUnpickleOps(value: String): UnpickleOps = new UnpickleOps(JSONPickle(value))
 }

--- a/server/src/test/scala/sbt/server/ProtocolTest.scala
+++ b/server/src/test/scala/sbt/server/ProtocolTest.scala
@@ -465,7 +465,7 @@ class ProtocolTest {
 
     for (s <- specifics) {
       def fromRaw(j: JsonValue): Message =
-        addWhatWeWereUnpickling(j.renderCompact)(j.parse[Message].get)
+        addWhatWeWereUnpickling(j.toJsonString)(j.parse[Message].get)
       def toRaw(m: Message): JsonValue =
         addWhatWeWerePickling(m)(JsonValue(m))
       val roundtrippedOption = fromRaw(toRaw(s))
@@ -644,8 +644,8 @@ class ProtocolTest {
           case JsonToObject =>
             if (!path.exists) { sys.error(s"$path didn't exist, maybe create with: ${SerializedValue(t)(format.pickler)}.") }
             else {
-              val json = JsonValue.parseJson(IO.read(path, IO.utf8)).get
-              val parsed = addWhatWeWereUnpickling(json.renderCompact + "\n\t\t * from file: " + path)(json.parse[T](format.unpickler).get)
+              val json = JsonValue.fromJsonString(IO.read(path, IO.utf8))
+              val parsed = addWhatWeWereUnpickling(json.toJsonString + "\n\t\t * from file: " + path)(json.parse[T](format.unpickler).get)
               (t, parsed) match {
                 // Throwable has a not-very-useful equals() in this case
                 case (t: Throwable, parsed: Throwable) => e(t, parsed)
@@ -915,7 +915,7 @@ class ProtocolTest {
       formatOption map { format =>
         val json = addWhatWeWerePickling(t)(JsonValue(t)(format.pickler))
         //System.err.println(s"${t} = ${Json.prettyPrint(json)}")
-        val parsed = addWhatWeWereUnpickling(json.renderCompact)(json.parse[T](format.unpickler).get)
+        val parsed = addWhatWeWereUnpickling(json.toJsonString)(json.parse[T](format.unpickler).get)
         (t, parsed) match {
           // Throwable has a not-very-useful equals() in this case
           case (t: Throwable, parsed: Throwable) => e(t, parsed)
@@ -953,7 +953,14 @@ class ProtocolTest {
       val json = SerializedValue(buildValue)
       // System.err.println(s"${buildValue} = ${json.toString}")
       val parsedValue = json.parse[protocol.BuildValue].getOrElse(throw new AssertionError(s"Failed to parse ${t} serialization ${json}"))
-      val parsedT = parsedValue.value[T](format.unpickler).getOrElse(throw new AssertionError(s"could not read back from build value ${t.getClass.getName} $t"))
+      import scala.util.{ Success, Failure }
+      val parsedT =
+        parsedValue.value[T](format.unpickler) match {
+          case Success(v) => v
+          case Failure(t) =>
+            t.printStackTrace()
+            throw new AssertionError(s"could not read back from build value ${t.getClass.getName} $t\n orig: $buildValue\njson: $json\nparsed: $parsedValue", t)
+        }
       val buildValueClass: Class[_] = t.getClass
       // Throwable has a not-very-useful equals() in this case
       if (classOf[Throwable].isAssignableFrom(buildValueClass)) {


### PR DESCRIPTION
Review by @havocp / @eed3si9n 

Note: this is but one minor step in the process of getting to a better Serialized Value.  Primary outcomes here:

1. Avoid serializing/parsing json strings like 30 times in their lifecycles
     - For this we altered the JSONPickle class directly
2. Expose what we need in SerializedValue and try to hide JsonValue (not succesful, but a start)
3. Remove the need for json4s native parser.  Instead we use Jawn and a hand-written toString implementation for now.  This can help avoid the re-ordering issues we saw before.


Again this is just a step in the right direction, not a full cleanup.  However, I'd like to move from working state to working state, hence the intermediate PR.