### PR TITLE
Bake a cake of picklers.

### DIFF
--- a/actor-client/src/main/scala/sbt/client/actors/SbtClientProxy.scala
+++ b/actor-client/src/main/scala/sbt/client/actors/SbtClientProxy.scala
@@ -8,9 +8,9 @@ import java.io.File
 import sbt.client.{ Subscription, SbtConnector, SbtClient, Interaction, SettingKey, TaskKey }
 import scala.concurrent.ExecutionContext
 import scala.util.{ Try, Success, Failure }
-import sbt.protocol.{ Analysis, CompileFailedException, TaskResult, ScopedKey, BuildValue, CompilationFailure }
 import sbt.protocol
-import sbt.protocol.CoreProtocol._
+import sbt.protocol.{ Analysis, CompileFailedException, TaskResult, ScopedKey, BuildValue, CompilationFailure }
+import sbt.serialization._
 import scala.language.existentials, scala.language.higherKinds
 import scala.collection.TraversableOnce
 

--- a/actor-client/src/main/scala/sbt/client/actors/SbtConnectionProxy.scala
+++ b/actor-client/src/main/scala/sbt/client/actors/SbtConnectionProxy.scala
@@ -7,7 +7,7 @@ import akka.actor._
 import java.io.File
 import sbt.client.{ Subscription, SbtConnector, SbtClient, SbtChannel }
 import scala.concurrent.ExecutionContext
-import sbt.protocol.CoreProtocol._
+import sbt.serialization._
 
 trait Request[Resp] {
   def sendTo: ActorRef

--- a/actor-client/src/test/scala/sbt/client/actors/SbtClientProxySpec.scala
+++ b/actor-client/src/test/scala/sbt/client/actors/SbtClientProxySpec.scala
@@ -13,7 +13,6 @@ import java.net.URI
 import scala.concurrent.Future
 import sbt.client.{ SettingKey, TaskKey }
 import sbt.serialization._
-import sbt.protocol.CoreProtocol._
 
 object SbtClientProxySpec {
   val sampleEvent: protocol.Event = protocol.ExecutionStarting(100)

--- a/client/src/main/scala/sbt/client/impl/SimpleClient.scala
+++ b/client/src/main/scala/sbt/client/impl/SimpleClient.scala
@@ -3,7 +3,6 @@ package sbt.client.impl
 
 import sbt.protocol
 import sbt.protocol._
-import sbt.protocol.CoreProtocol._
 import sbt.serialization._
 import sbt.client.{ SbtChannel, SbtClient, Subscription, BuildStructureListener, EventListener, ValueListener, RawValueListener, SettingKey, TaskKey, Interaction }
 import java.net.SocketException

--- a/commons/protocol/src/main/scala/sbt/protocol/Keys.scala
+++ b/commons/protocol/src/main/scala/sbt/protocol/Keys.scala
@@ -2,7 +2,6 @@ package sbt.protocol
 
 import java.net.URI
 import sbt.serialization._
-import sbt.serialization.functions._
 
 /**
  * This represents a "key" in sbt.
@@ -13,7 +12,6 @@ final case class AttributeKey(name: String, manifest: TypeExpression) {
   override def toString = "AttributeKey[" + manifest + "](\"" + name + "\")"
 }
 object AttributeKey {
-  import CoreProtocol._
   require(implicitly[Unpickler[TypeExpression]] ne null)
   implicit val unpickler: Unpickler[AttributeKey] = genUnpickler[AttributeKey]
   implicit val pickler: SPickler[AttributeKey] = genPickler[AttributeKey]
@@ -30,7 +28,6 @@ object AttributeKey {
  */
 final case class ProjectReference(build: URI, name: String)
 object ProjectReference {
-  import CoreProtocol._
   require(implicitly[Unpickler[java.net.URI]] ne null)
   implicit val unpickler: Unpickler[ProjectReference] = genUnpickler[ProjectReference]
   implicit val pickler: SPickler[ProjectReference] = genPickler[ProjectReference]
@@ -57,7 +54,6 @@ final case class SbtScope(build: Option[URI] = None,
   }
 }
 object SbtScope {
-  import CoreProtocol._
   require(implicitly[Unpickler[ProjectReference]] ne null)
   require(implicitly[Unpickler[URI]] ne null)
   require(implicitly[Unpickler[AttributeKey]] ne null)
@@ -71,7 +67,6 @@ final case class ScopedKey(key: AttributeKey, scope: SbtScope) {
     key + " in " + scope
 }
 object ScopedKey {
-  import CoreProtocol._
   require(implicitly[Unpickler[SbtScope]] ne null)
   require(implicitly[Unpickler[AttributeKey]] ne null)
   implicit val unpickler: Unpickler[ScopedKey] = genUnpickler[ScopedKey]
@@ -80,7 +75,6 @@ object ScopedKey {
 /** A means of JSON-serializing key lists from sbt to our client. */
 final case class KeyList(keys: Vector[ScopedKey])
 object KeyList {
-  import CoreProtocol._
   implicit val unpickler: Unpickler[KeyList] = genUnpickler[KeyList]
   implicit val pickler: SPickler[KeyList] = genPickler[KeyList]
 }
@@ -91,7 +85,6 @@ final case class MinimalProjectStructure(
   // Class names of plugins used by this project.
   plugins: Vector[String])
 object MinimalProjectStructure {
-  import CoreProtocol._
   implicit val unpickler: Unpickler[MinimalProjectStructure] = genUnpickler[MinimalProjectStructure]
   implicit val pickler: SPickler[MinimalProjectStructure] = genPickler[MinimalProjectStructure]
 }
@@ -102,7 +95,6 @@ final case class MinimalBuildStructure(
   // "unwind" on the client side into ScopedKeys.
   )
 object MinimalBuildStructure {
-  import CoreProtocol._
   implicit val unpickler: Unpickler[MinimalBuildStructure] = genUnpickler[MinimalBuildStructure]
   implicit val pickler: SPickler[MinimalBuildStructure] = genPickler[MinimalBuildStructure]
 }

--- a/commons/protocol/src/main/scala/sbt/protocol/Values.scala
+++ b/commons/protocol/src/main/scala/sbt/protocol/Values.scala
@@ -1,6 +1,6 @@
 package sbt.protocol
 
-import sbt.serialization._, sbt.serialization.functions._
+import sbt.serialization._
 import scala.util.{ Try, Success, Failure }
 
 /**
@@ -18,7 +18,6 @@ final case class BuildValue(serialized: SerializedValue, stringValue: String) {
 }
 
 object BuildValue {
-  import CoreProtocol._
   def apply[T](value: T)(implicit pickler: SPickler[T]): BuildValue = {
     BuildValue(serialized = SerializedValue(value)(pickler), stringValue = value.toString)
   }
@@ -49,7 +48,6 @@ final case class ThrowableDeserializers(readers: Map[Manifest[_], Unpickler[_]] 
  * Represents the outcome of a task. The outcome can be a value or an exception.
  */
 sealed trait TaskResult {
-  import CoreProtocol._
 
   /** Returns whether or not a task was executed succesfully. */
   def isSuccess: Boolean
@@ -82,13 +80,11 @@ final case class TaskFailure(cause: BuildValue) extends TaskResult {
 }
 
 object TaskSuccess {
-  import CoreProtocol._
   implicit val pickler: SPickler[TaskSuccess] = genPickler[TaskSuccess]
   implicit val unpickler: Unpickler[TaskSuccess] = genUnpickler[TaskSuccess]
 }
 
 object TaskFailure {
-  import CoreProtocol._
   implicit val pickler: SPickler[TaskFailure] = genPickler[TaskFailure]
   implicit val unpickler: Unpickler[TaskFailure] = genUnpickler[TaskFailure]
 }
@@ -97,7 +93,6 @@ object TaskFailure {
 // the macros won't know all the subtypes of TaskResult if we
 // put this companion object earlier in the file.
 object TaskResult {
-  import CoreProtocol._
   implicit val pickler: SPickler[TaskResult] = genPickler[TaskResult]
   implicit val unpickler: Unpickler[TaskResult] = genUnpickler[TaskResult]
 }

--- a/commons/protocol/src/main/scala/sbt/protocol/package.scala
+++ b/commons/protocol/src/main/scala/sbt/protocol/package.scala
@@ -1,13 +1,8 @@
 package sbt
 
-import scala.pickling.{ PReader, FastTypeTag }
-import scala.util.control.NonFatal
-
 import sbt.serialization._
-import sbt.serialization.functions._
 
 package object protocol {
-  import CoreProtocol._
   import sbt.serialization.CanToString
 
   //implicit def attributedPickler[T](implicit pickler: SPickler[T]): SPickler[Attributed[T]] = ???
@@ -92,8 +87,8 @@ package object protocol {
   implicit val compilationFailureUnpickler = genUnpickler[CompilationFailure]
   implicit val moduleIdPickler = genPickler[ModuleId]
   implicit object moduleIdUnpickler extends Unpickler[ModuleId] {
-    private val stringUnpickler = CoreProtocol.stringPickler
-    private val attrsUnpickler = CoreProtocol.stringMapPickler[String]
+    private val stringUnpickler = sbt.serialization.stringPickler
+    private val attrsUnpickler = sbt.serialization.stringMapPickler[String]
     override def unpickle(tag: String, reader: PReader): Any = {
       reader.pushHints()
       reader.hintTag(this.tag)

--- a/commons/protocol/src/test/scala/sbt/protocol/PlayStartedEvent.scala
+++ b/commons/protocol/src/test/scala/sbt/protocol/PlayStartedEvent.scala
@@ -1,14 +1,10 @@
 package sbt.protocol.spec
 
-import sbt.protocol.{ TaskEventUnapply, BackgroundJobEventUnapply, CoreProtocol }
+import sbt.protocol.{ TaskEventUnapply, BackgroundJobEventUnapply }
 import sbt.serialization._
-import sbt.serialization.functions._
-import sbt.serialization.json._
 
 final case class PlayStartedEvent(port: Int)
 object PlayStartedEvent extends TaskEventUnapply[PlayStartedEvent] {
-  import CoreProtocol._
-
   implicit val pickler = genPickler[PlayStartedEvent]
   implicit val unpickler = genUnpickler[PlayStartedEvent]
 }

--- a/commons/protocol/src/test/scala/sbt/protocol/ProtocolSpec.scala
+++ b/commons/protocol/src/test/scala/sbt/protocol/ProtocolSpec.scala
@@ -1,7 +1,7 @@
 package sbt.protocol.spec
 
 import sbt.protocol
-import sbt.protocol.{ Message, CoreProtocol }
+import sbt.protocol.{ Message }
 import org.junit.Assert._
 import org.junit._
 import java.io.File
@@ -11,13 +11,9 @@ import sbt.serialization.spec.JUnitUtil._
 import JUnitMessageUtil._
 import xsbti.Severity.{ Info, Warn, Error }
 import scala.util.{ Try, Success, Failure }
-import sbt.serialization.json._
-import scala.pickling.PickleOps
 import sbt.serialization._
-import scala.pickling.Defaults.pickleOps
 
 class ProtocolTest {
-  import CoreProtocol._
 
   val key = protocol.AttributeKey("name", TypeExpression.parse("java.lang.String")._1)
   val build = new java.net.URI("file:///test/project")

--- a/commons/protocol/src/test/scala/sbt/protocol/SerializedValuePicklerSpec.scala
+++ b/commons/protocol/src/test/scala/sbt/protocol/SerializedValuePicklerSpec.scala
@@ -8,13 +8,11 @@ import java.net.URI
 import SpecsUtil._
 import sbt.serialization.spec.JUnitUtil._
 import sbt.serialization._
-import sbt.serialization.json._
 import protocol.TaskEventUnapply
 
 import scala.pickling.Defaults.pickleOps
 
 class SerializedValuePicklerTest {
-  import protocol.CoreProtocol._
 
   @Test
   def testRoundtripInt: Unit = {

--- a/commons/protocol/src/test/scala/sbt/protocol/TypeExpressionPicklerSpec.scala
+++ b/commons/protocol/src/test/scala/sbt/protocol/TypeExpressionPicklerSpec.scala
@@ -5,13 +5,11 @@ import org.junit.Assert._
 import org.junit._
 import java.io.File
 import java.net.URI
-import scala.pickling.Defaults.pickleOps
-import sbt.serialization._, json._
+import sbt.serialization._
 import sbt.serialization.spec.JUnitUtil._
 import SpecsUtil._
 
 class TypeExpressionPicklerTest {
-  import protocol.CoreProtocol._
 
   @Test
   def testRoundtripStringType: Unit = {

--- a/integration-tests/src/main/scala/com/typesafe/sbtrc/it/execution/TestExecution.scala
+++ b/integration-tests/src/main/scala/com/typesafe/sbtrc/it/execution/TestExecution.scala
@@ -4,7 +4,6 @@ package execution
 
 import sbt.client._
 import sbt.protocol._
-import sbt.protocol.CoreProtocol._
 import sbt.serialization._
 import java.io.File
 import java.util.concurrent.{ LinkedBlockingQueue, Executors }

--- a/integration-tests/src/main/scala/com/typesafe/sbtrc/it/loading/CanCancelTasks.scala
+++ b/integration-tests/src/main/scala/com/typesafe/sbtrc/it/loading/CanCancelTasks.scala
@@ -4,7 +4,6 @@ package loading
 
 import sbt.client._
 import sbt.protocol._
-import sbt.protocol.CoreProtocol._
 import java.util.concurrent.Executors
 import concurrent.duration.Duration.Inf
 import concurrent.{ Await, ExecutionContext, Promise }

--- a/integration-tests/src/main/scala/com/typesafe/sbtrc/it/loading/CanKillServer.scala
+++ b/integration-tests/src/main/scala/com/typesafe/sbtrc/it/loading/CanKillServer.scala
@@ -4,7 +4,7 @@ package loading
 
 import sbt.client._
 import sbt.protocol._
-import sbt.protocol.CoreProtocol._
+import sbt.serialization._
 import java.util.concurrent.Executors
 import concurrent.duration.Duration.Inf
 import concurrent.{ Await, ExecutionContext }

--- a/integration-tests/src/main/scala/com/typesafe/sbtrc/it/loading/CanLoadSimpleProject.scala
+++ b/integration-tests/src/main/scala/com/typesafe/sbtrc/it/loading/CanLoadSimpleProject.scala
@@ -11,8 +11,6 @@ import java.util.concurrent.LinkedBlockingQueue
 import scala.concurrent.duration.Duration.Inf
 import scala.concurrent.{ Await, ExecutionContext, Promise, Future }
 import scala.util.{ Success, Failure }
-import scala.pickling.Unpickler
-import sbt.protocol.CoreProtocol._
 
 class CanLoadSimpleProject extends SbtClientTest {
   // TODO - Don't hardcode sbt versions, unless we have to...

--- a/integration-tests/src/main/scala/com/typesafe/sbtrc/it/loading/CanUseUiInteractionPlugin.scala
+++ b/integration-tests/src/main/scala/com/typesafe/sbtrc/it/loading/CanUseUiInteractionPlugin.scala
@@ -30,13 +30,11 @@ class CanUseUiInteractionPlugin extends SbtClientTest {
        |final case class SerializedThing(name: String, value: Int)
        |object SerializedThing {
        |  import sbt.serialization._
-       |  // TODO - we don't want this to gunky everything up.
-       |  import sbt.protocol.CoreProtocol._
-       |  implicit val pickler: SPickler[SerializedThing] = SPickler.generate[SerializedThing]
-       |  implicit val unpickler: Unpickler[SerializedThing] = Unpickler.generate[SerializedThing]
+       |  implicit val pickler: SPickler[SerializedThing] = genPickler[SerializedThing]
+       |  implicit val unpickler: Unpickler[SerializedThing] = genUnpickler[SerializedThing]
        |}
        |object TestThingPlugin {
-       |   import sbt.protocol.CoreProtocol._  // For SbtSerializer
+       |   import sbt.serialization._
        |   val makeTestThing = taskKey[SerializedThing]("makes a test thing")
        |   def settings: Seq[Setting[_]] =
        |     Seq(

--- a/integration-tests/src/main/scala/com/typesafe/sbtrc/it/loading/SerializedThing.scala
+++ b/integration-tests/src/main/scala/com/typesafe/sbtrc/it/loading/SerializedThing.scala
@@ -6,7 +6,6 @@ final case class SerializedThing(name: String, value: Int)
 object SerializedThing {
   import sbt.serialization._
   // TODO - we don't want this to gunky everything up.
-  import sbt.protocol.CoreProtocol._
 
   implicit val pickler: SPickler[SerializedThing] = SPickler.generate[SerializedThing]
   implicit val unpickler: Unpickler[SerializedThing] = Unpickler.generate[SerializedThing]

--- a/serialization/src/main/scala/sbt/serialization/CustomPicklerUnpickler.scala
+++ b/serialization/src/main/scala/sbt/serialization/CustomPicklerUnpickler.scala
@@ -1,18 +1,23 @@
 package sbt.serialization
 
-import sbt.serialization.pickler.{
+// TODO - Why are type aliases not workign?
+import scala.pickling.pickler.{
   PrimitivePicklers,
   PrimitiveArrayPicklers,
+  RefPicklers
+}
+
+import sbt.serialization.pickler.{
   OptionPicklers,
   ThrowablePicklers,
-  RefPicklers,
   VectorPicklers,
   ListPicklers,
   ArrayPicklers,
   SeqPicklers,
   StringMapPicklers,
   JavaExtraPicklers,
-  TypeExpressionPicklers
+  TypeExpressionPicklers,
+  SerializationPicklers
 }
 
 trait CustomPicklers extends PrimitivePicklers
@@ -22,7 +27,8 @@ trait CustomPicklers extends PrimitivePicklers
   with JavaExtraPicklers
   with TypeExpressionPicklers
   with RefPicklers
-  with LowPriorityCustomPicklers {}
+  with LowPriorityCustomPicklers
+  with SerializationPicklers {}
 
 trait LowPriorityCustomPicklers extends VectorPicklers
   with ListPicklers

--- a/serialization/src/main/scala/sbt/serialization/json/JSONPickleFormat.scala
+++ b/serialization/src/main/scala/sbt/serialization/json/JSONPickleFormat.scala
@@ -392,6 +392,7 @@ package json {
         val keys =
           state.current.asInstanceOf[JObject].values.keys.toList.sorted.map(k => JString(k))
         RawJsValue(JArray(keys), state)
+        // TODO - what do we do if we're at a JNothing here...
       } else RawJsValue(state.current.asInstanceOf[JObject] \ name, state)
       val nested = new VerifyingJSONPickleReader(format, nextState)
       if (this.areHintsPinned) {

--- a/serialization/src/main/scala/sbt/serialization/package.scala
+++ b/serialization/src/main/scala/sbt/serialization/package.scala
@@ -1,13 +1,27 @@
 package sbt
 
-package object serialization {
+/**
+ * A package object which can be used to create new serializers.
+ *
+ * This package supports creating Pickler/Unpickler functions which can serialize arbitrary types.  See the
+ * SerializedValue type for what formats this library supports serializing into.
+ */
+package object serialization extends SerializationFunctions with CustomPicklers with SbtSerializers {
   type SPickler[A] = scala.pickling.SPickler[A]
   val SPickler = scala.pickling.SPickler
   type Unpickler[A] = scala.pickling.Unpickler[A]
   val Unpickler = scala.pickling.Unpickler
-  val functions: SerializationFunctions = new SerializationFunctions {}
+  // These are exposed for custom implementations of picklers.
+  type FastTypeTag[A] = scala.pickling.FastTypeTag[A]
+  type PReader = scala.pickling.PReader
+  type PBuilder = scala.pickling.PBuilder
 
   // pickling macros need FastTypeTag$ to have been initialized;
   // if things ever compile with this removed, it can be removed.
   private val __forceInitializeFastTypeTagCompanion = scala.pickling.FastTypeTag
+
+  // All generated picklers are required to be static-only in this library.
+  implicit val StaticOnly = scala.pickling.static.StaticOnly
+
+  type directSubclasses = _root_.scala.pickling.directSubclasses
 }

--- a/serialization/src/main/scala/sbt/serialization/pickler/JavaExtraPicklers.scala
+++ b/serialization/src/main/scala/sbt/serialization/pickler/JavaExtraPicklers.scala
@@ -4,6 +4,8 @@ package pickler
 import java.io.File
 import java.net.URI
 import scala.pickling.{ FastTypeTag, PBuilder, PReader, PicklingException }
+// TODO - Why is alias not working.
+import scala.pickling.pickler.{ PrimitivePicklers, RefPicklers }
 
 /** Contains implementation-details of "can to strings" for Java/sbt 'raw' types. */
 object JavaExtraPicklers {

--- a/serialization/src/main/scala/sbt/serialization/pickler/Option.scala
+++ b/serialization/src/main/scala/sbt/serialization/pickler/Option.scala
@@ -2,6 +2,8 @@ package sbt.serialization
 package pickler
 
 import scala.pickling.{ FastTypeTag, PBuilder, PReader, PicklingException }
+// TODO - Why is alias not working.
+import scala.pickling.pickler.PrimitivePicklers
 
 trait OptionPicklers extends PrimitivePicklers with RichTypes {
   implicit def optionPickler[A: FastTypeTag](implicit elemPickler: SPickler[A], elemUnpickler: Unpickler[A], collTag: FastTypeTag[Option[A]]): SPickler[Option[A]] with Unpickler[Option[A]] =

--- a/serialization/src/main/scala/sbt/serialization/pickler/SerializedValue.scala
+++ b/serialization/src/main/scala/sbt/serialization/pickler/SerializedValue.scala
@@ -2,6 +2,5 @@ package sbt.serialization
 package pickler
 
 trait SerializationPicklers {
-
-  implicit val serializedValuePickler = SerializedValue.pickler
+  implicit val serializedValuePickler: SPickler[SerializedValue] with Unpickler[SerializedValue] = SerializedValue.pickler
 }

--- a/serialization/src/main/scala/sbt/serialization/pickler/Throwable.scala
+++ b/serialization/src/main/scala/sbt/serialization/pickler/Throwable.scala
@@ -1,8 +1,9 @@
 package sbt.serialization
 package pickler
 
+// TODO - Why is alias not working.
+import scala.pickling.pickler.{ PrimitivePicklers, RefPicklers }
 import scala.pickling.{ FastTypeTag, PBuilder, PReader, PicklingException }
-import scala.pickling.static._
 
 private[pickler] final case class StackTraceElementDeserialized(declaringClass: String,
   methodName: String,
@@ -13,8 +14,6 @@ trait ThrowablePicklers extends PrimitivePicklers with OptionPicklers with Vecto
 
   implicit val stackTracePickler: SPickler[StackTraceElementDeserialized] = SPickler.generate[StackTraceElementDeserialized]
   implicit val stackTraceUnickler: Unpickler[StackTraceElementDeserialized] = Unpickler.generate[StackTraceElementDeserialized]
-  implicit val pickler = SPickler.generate[StackTraceElementDeserialized]
-  implicit val unpickler = Unpickler.generate[StackTraceElementDeserialized]
 
   // TODO why isn't this in LowPriority / what goes in Low and what goes here?
   implicit object throwablePicklerUnpickler extends SPickler[Throwable] with Unpickler[Throwable] {

--- a/serialization/src/main/scala/sbt/serialization/pickler/TypeExpression.scala
+++ b/serialization/src/main/scala/sbt/serialization/pickler/TypeExpression.scala
@@ -3,12 +3,11 @@ package pickler
 
 import scala.pickling.FastTypeTag
 
-
 object TypeExpressionPicklers {
   private val typeExpressionCanToString: CanToString[TypeExpression] = CanToString(
-  _.toString, {
-    s: String => TypeExpression.parse(s)._1
-  })
+    _.toString, {
+      s: String => TypeExpression.parse(s)._1
+    })
 }
 /** Provides a layer of pickler cake for type expressoins. */
 trait TypeExpressionPicklers extends JavaExtraPicklers {

--- a/serialization/src/test/scala/sbt/serialization/PicklerGrowableSpec.scala
+++ b/serialization/src/test/scala/sbt/serialization/PicklerGrowableSpec.scala
@@ -2,16 +2,11 @@ package sbt.serialization.spec
 
 import org.junit.Assert._
 import org.junit._
-import scala.pickling.{ PickleOps, UnpickleOps }
-import scala.pickling.Defaults.pickleOps
-import sbt.serialization._, sbt.serialization.functions._, sbt.serialization.json._
+import sbt.serialization._
 import JUnitUtil._
 
 case class Foo(x: Int, y: Option[Int])
 object Foo {
-  val coreProtocol: CustomPicklers = new CustomPicklers {}
-  import coreProtocol._
-
   implicit val pickler = genPickler[Foo]
   implicit val unpickler = genUnpickler[Foo]
 }
@@ -19,12 +14,12 @@ object Foo {
 class PicklerGrowableTest {
   @Test
   def testUnpickleWithExtra: Unit = {
-    extraFieldExample.unpickle[Foo] must_== Foo(1, Some(1))
+    SerializedValue.fromJsonString(extraFieldExample).parse[Foo].get must_== Foo(1, Some(1))
   }
 
   @Test
   def testUnpickleWithMissing: Unit = {
-    missingFieldExample.unpickle[Foo] must_== Foo(1, None)
+    SerializedValue.fromJsonString(missingFieldExample).parse[Foo].get must_== Foo(1, None)
   }
 
   lazy val extraFieldExample = """{

--- a/serialization/src/test/scala/sbt/serialization/PicklerTypeSpec.scala
+++ b/serialization/src/test/scala/sbt/serialization/PicklerTypeSpec.scala
@@ -2,15 +2,11 @@ package sbt.serialization.spec
 
 import org.junit.Assert._
 import org.junit._
-import scala.pickling.{ PickleOps, UnpickleOps, PicklingException }
-import sbt.serialization._, sbt.serialization.functions._, sbt.serialization.json._
+import scala.pickling.{ PicklingException }
+import sbt.serialization._
 import JUnitUtil._
-import scala.pickling.Defaults.pickleOps
 
 object Fruits {
-  val coreProtocol: CustomPicklers = new CustomPicklers {}
-  import coreProtocol._
-
   sealed trait Fruit
   case class Apple(x: Int) extends Fruit
   object Apple {
@@ -34,33 +30,33 @@ class PicklerTypeTest {
 
   @Test
   def testPickleApple: Unit = {
-    assertEquals("Apple(1)", appleExample, Apple(1).pickle.value)
+    assertEquals("Apple(1)", appleExample, SerializedValue(Apple(1)).toJsonString)
   }
 
   @Test
   def testUnpickleApple: Unit = {
-    appleExample.unpickle[Apple] must_== Apple(1)
+    SerializedValue.fromJsonString(appleExample).parse[Apple].get must_== Apple(1)
   }
 
   @Test
   def testUnpickleFruit: Unit = {
-    appleExample.unpickle[Fruit] must_== Apple(1)
+    SerializedValue.fromJsonString(appleExample).parse[Fruit].get must_== Apple(1)
   }
 
   @Test
   def testUnpickleOrange: Unit = {
-    appleExample.unpickle[Orange] must_== Orange(1)
+    SerializedValue.fromJsonString(appleExample).parse[Orange].get must_== Orange(1)
   }
 
   @Test
   def testUnpickleOrangeFromUnknown: Unit = {
-    unknownTypeExample.unpickle[Orange] must_== Orange(1)
+    SerializedValue.fromJsonString(unknownTypeExample).parse[Orange].get must_== Orange(1)
   }
 
   @Test
   def testUnpickleFruitFromUnknown: Unit = {
     try {
-      unknownTypeExample.unpickle[Fruit]
+      SerializedValue(unknownTypeExample).parse[Fruit].get
       sys.error("didn't fail")
     } catch {
       case _: PicklingException => ()

--- a/server/src/main/scala/sbt/server/DynamicSerialization.scala
+++ b/server/src/main/scala/sbt/server/DynamicSerialization.scala
@@ -104,7 +104,6 @@ private final case class ConcreteDynamicSerialization(registered: Map[Manifest[_
 }
 
 private object ConcreteDynamicSerialization {
-  import CoreProtocol._
   private val defaultSerializationMemosByManifest =
     scala.collection.concurrent.TrieMap[Manifest[_], SbtSerializer[_]]()
   private val defaultSerializationMemosByClass =
@@ -237,7 +236,6 @@ private object ConcreteDynamicSerialization {
 }
 
 private object NonTrivialSerializers {
-  import CoreProtocol._
   private sealed trait RegisteredSbtSerializer {
     type T
     def manifest: Manifest[T]

--- a/server/src/test/scala/sbt/server/ProtocolTest.scala
+++ b/server/src/test/scala/sbt/server/ProtocolTest.scala
@@ -17,11 +17,7 @@ import Arbitrary.arbitrary
 import org.scalacheck.Prop.forAll
 import sbt.protocol
 import sbt.protocol._
-import sbt.protocol.CoreProtocol._
 import sbt.serialization._
-import sbt.serialization.functions._
-// TODO - put this in serialziatoin package or something.
-import scala.pickling.Defaults.pickleOps
 
 object ProtocolGenerators {
   import scala.annotation.tailrec


### PR DESCRIPTION
* Bake default picklers into serialziatoin package object.
* Remove as many refernces to scala-pickling.
* REmoves CoreProtocol for just importing sbt.serialization._
* Fixes all tests


THE CAKE IS BAKED.  review by @eed3si9n @havocp 