### PR TITLE
Introduce "daemon mode" for clients, they don't keep server alive

### DIFF
--- a/actor-client/src/test/scala/sbt/client/actors/FakeSbtClient.scala
+++ b/actor-client/src/test/scala/sbt/client/actors/FakeSbtClient.scala
@@ -252,4 +252,12 @@ final class FakeSbtClient(refFactory: ActorRefFactory,
       _ <- ask(watchQueue, WatchSubscriptionManager.StopAll)
     } {}
   }
+
+  @volatile
+  var daemon = false
+
+  def setDaemon(value: Boolean): Future[Unit] = {
+    daemon = value
+    Future.successful(())
+  }
 }

--- a/actor-client/src/test/scala/sbt/client/actors/SbtClientProxySpec.scala
+++ b/actor-client/src/test/scala/sbt/client/actors/SbtClientProxySpec.scala
@@ -221,4 +221,16 @@ class SbtClientProxySpec extends DefaultSpecification {
       }
     }
   }
+
+  @Test
+  def testSetDaemon(): Unit = withHelper { helper =>
+    import helper._
+    withFakeSbtClient() { client =>
+      val cp = system.actorOf(Props(new SbtClientProxy(client, global, x => testActor ! x)))
+      Assert.assertFalse("client starts not in daemon mode", client.daemon)
+      cp ! SetDaemon(true, testActor)
+      Assert.assertEquals(expectMsgType[DaemonSet.type], DaemonSet)
+      Assert.assertTrue("client was set to daemon mode", client.daemon)
+    }
+  }
 }

--- a/client/src/main/scala/sbt/client/SbtClient.scala
+++ b/client/src/main/scala/sbt/client/SbtClient.scala
@@ -20,6 +20,15 @@ trait SbtClient extends Closeable {
   def humanReadableName: String
 
   /**
+   * Set whether the client keeps the sbt server alive. Daemon clients do not prevent
+   * the server from exiting (it exits after a timeout). Typically, user-visible tools
+   * should not be daemon clients.
+   * @param daemon true if the server should feel free to exit with us connected
+   * @returns a future which is completed if the request is ack'd by the server
+   */
+  def setDaemon(daemon: Boolean): Future[Unit]
+
+  /**
    * Watch the build structure, receiving notification when it changes.
    * When initially calling watchBuild(), at least one initial notification
    * is guaranteed to be sent (asynchronously) with the latest build structure.

--- a/client/src/main/scala/sbt/client/impl/SimpleClient.scala
+++ b/client/src/main/scala/sbt/client/impl/SimpleClient.scala
@@ -25,6 +25,10 @@ private[client] final class SimpleSbtClient(override val channel: SbtChannel) ex
   override def configName: String = channel.configName
   override def humanReadableName: String = channel.humanReadableName
 
+  override def setDaemon(daemon: Boolean): Future[Unit] = {
+    channel.sendJson[Message](DaemonRequest(daemon))
+  }
+
   def watchBuild(listener: BuildStructureListener)(implicit ex: ExecutionContext): Subscription = {
     val sub = buildEventManager.watch(listener)(ex)
 

--- a/commons/protocol/src/main/scala/sbt/protocol/Protocol.scala
+++ b/commons/protocol/src/main/scala/sbt/protocol/Protocol.scala
@@ -15,6 +15,7 @@ sealed trait Message {
 
 /** Represents requests that go down into sbt. */
 @directSubclasses(Array(classOf[RegisterClientRequest],
+  classOf[DaemonRequest],
   classOf[CancelExecutionRequest],
   classOf[ExecutionRequest],
   classOf[KeyExecutionRequest],
@@ -75,6 +76,9 @@ sealed trait ExecutionEngineEvent extends Event
 final case class ClientInfo(uuid: String, configName: String, humanReadableName: String)
 
 final case class RegisterClientRequest(info: ClientInfo) extends Request
+
+/** whether the client should prevent the server from exiting */
+final case class DaemonRequest(daemon: Boolean) extends Request
 
 final case class CancelExecutionRequest(id: Long) extends Request
 final case class CancelExecutionResponse(attempted: Boolean) extends Response
@@ -682,6 +686,8 @@ object Message {
   private implicit val sendSyntheticBuildChangedUnpickler = genUnpickler[SendSyntheticBuildChanged]
   private implicit val sendSyntheticValueChangedPickler = genPickler[SendSyntheticValueChanged]
   private implicit val sendSyntheticValueChangedUnpickler = genUnpickler[SendSyntheticValueChanged]
+  private implicit val daemonRequestPickler = genPickler[DaemonRequest]
+  private implicit val daemonRequestUnpickler = genUnpickler[DaemonRequest]
   private implicit val taskEventPickler = genPickler[TaskEvent]
   private implicit val taskEventUnpickler = genUnpickler[TaskEvent]
   private implicit val taskFinishedPickler = genPickler[TaskFinished]

--- a/integration-tests/src/main/scala/com/typesafe/sbtrc/it/loading/CanLoadSimpleProject.scala
+++ b/integration-tests/src/main/scala/com/typesafe/sbtrc/it/loading/CanLoadSimpleProject.scala
@@ -51,6 +51,9 @@ class CanLoadSimpleProject extends SbtClientTest {
     assert(project.id.name == "test", "failed to discover project name == file name.")
     assert(project.plugins contains "sbt.plugins.JvmPlugin", s"failed to discover default plugins in project, found: ${project.plugins.mkString(", ")}")
 
+    waitWithError(client.setDaemon(true), "Did not get a response to daemon=true")
+    waitWithError(client.setDaemon(false), "Did not get a response to daemon=false")
+
     val compileKeysFuture = client.lookupScopedKey("compile")
     val compileKeys = waitWithError(compileKeysFuture, "Never received key lookup response!")
     assert(!compileKeys.isEmpty && compileKeys.head.key.name == "compile", s"Failed to find compile key: $compileKeys!")

--- a/protocol-test/src/test/resource/saved-protocol/0.1/message/daemon_req.json
+++ b/protocol-test/src/test/resource/saved-protocol/0.1/message/daemon_req.json
@@ -1,0 +1,1 @@
+{"$type":"sbt.protocol.DaemonRequest","daemon":true}

--- a/protocol-test/src/test/scala/sbt/protocol/ProtocolTest.scala
+++ b/protocol-test/src/test/scala/sbt/protocol/ProtocolTest.scala
@@ -137,6 +137,7 @@ class ProtocolTest {
 
     val specifics = Seq(
       // Requests
+      protocol.DaemonRequest(true),
       protocol.KillServerRequest(),
       protocol.ReadLineRequest(42, "HI", true),
       protocol.ReadLineResponse(Some("line")),
@@ -412,6 +413,7 @@ class ProtocolTest {
       Vector(protocol.Problem("something", xsbti.Severity.Error, "stuff didn't go well", FakePosition)))) { _ / "complex" / "compile_failed.json" }
 
     // message
+    oneWayTrip[Message](protocol.DaemonRequest(true)) { _ / "message" / "daemon_req.json" }
     oneWayTrip[Message](protocol.KillServerRequest()) { _ / "message" / "kill_server_req.json" }
     oneWayTrip[Message](protocol.ReadLineRequest(42, "HI", true)) { _ / "message" / "readline_request.json" }
     oneWayTrip[Message](protocol.ReadLineResponse(Some("line"))) { _ / "message" / "readline_response.json" }

--- a/server/src/main/scala/sbt/server/RequestProcessor.scala
+++ b/server/src/main/scala/sbt/server/RequestProcessor.scala
@@ -349,6 +349,8 @@ class RequestProcessor(
       //// If you change any of these, you probably also need to change
       //// handleRequestsWithBuildState below.
 
+      case DaemonRequest(daemon) =>
+        client.daemon = daemon
       case KillServerRequest() =>
         quit()
       case ListenToEvents() =>
@@ -376,6 +378,8 @@ class RequestProcessor(
       //// without losing the match exhaustiveness warnings. If you change
       //// these change above too.
 
+      case DaemonRequest(daemon) =>
+        client.daemon = daemon
       case KillServerRequest() =>
         quit()
       case ListenToEvents() =>

--- a/server/src/main/scala/sbt/server/RequestProcessor.scala
+++ b/server/src/main/scala/sbt/server/RequestProcessor.scala
@@ -343,6 +343,10 @@ class RequestProcessor(
     eventSink.removeEventListener(client)
     client.reply(serial, ReceivedResponse())
   }
+  private def setDaemon(client: LiveClient, serial: Long, value: Boolean): Unit = {
+    client.daemon = value
+    client.reply(serial, ReceivedResponse())
+  }
   private def handleRequestsNoBuildState(client: LiveClient, serial: Long, request: Request): Unit =
     request match {
 
@@ -350,7 +354,7 @@ class RequestProcessor(
       //// handleRequestsWithBuildState below.
 
       case DaemonRequest(daemon) =>
-        client.daemon = daemon
+        setDaemon(client, serial, daemon)
       case KillServerRequest() =>
         quit()
       case ListenToEvents() =>
@@ -379,7 +383,7 @@ class RequestProcessor(
       //// these change above too.
 
       case DaemonRequest(daemon) =>
-        client.daemon = daemon
+        setDaemon(client, serial, daemon)
       case KillServerRequest() =>
         quit()
       case ListenToEvents() =>

--- a/server/src/main/scala/sbt/server/SbtServerSocketHandler.scala
+++ b/server/src/main/scala/sbt/server/SbtServerSocketHandler.scala
@@ -103,12 +103,15 @@ class SbtServerSocketHandler(serverSocket: ServerSocket, msgHandler: SocketMessa
           case _: InterruptedException | _: SocketTimeoutException =>
             if (running.get) {
               log.log("Checking to see if clients are empty...")
+              val (daemonClients, nonDaemonClients) = clients.partition(_.daemon)
               // Here we need to check to see if we should shut ourselves down.
-              if (clients.isEmpty) {
-                log.log("No clients connected after 3 min.  Shutting down.")
+              if (nonDaemonClients.isEmpty) {
+                log.log("No non-daemon clients connected after 3 min. Shutting down.")
+                if (daemonClients.nonEmpty)
+                  log.log(s"${daemonClients.size} daemon clients are connected.")
                 running.set(false)
               } else {
-                log.log("We have a client, continuing serving connections.")
+                log.log(s"We have ${daemonClients.size} non-daemon clients, continuing serving connections.")
               }
             } else {
               log.log(s"socket exception, running=false, exiting")

--- a/server/src/main/scala/sbt/server/SbtServerSocketHandler.scala
+++ b/server/src/main/scala/sbt/server/SbtServerSocketHandler.scala
@@ -111,7 +111,7 @@ class SbtServerSocketHandler(serverSocket: ServerSocket, msgHandler: SocketMessa
                   log.log(s"${daemonClients.size} daemon clients are connected.")
                 running.set(false)
               } else {
-                log.log(s"We have ${daemonClients.size} non-daemon clients, continuing serving connections.")
+                log.log(s"We have ${nonDaemonClients.size} non-daemon clients, continuing serving connections.")
               }
             } else {
               log.log(s"socket exception, running=false, exiting")

--- a/server/src/main/scala/sbt/server/ServerListener.scala
+++ b/server/src/main/scala/sbt/server/ServerListener.scala
@@ -52,6 +52,9 @@ abstract class LiveClient extends SbtClient {
   def configName: String
   def humanReadableName: String
 
+  @volatile
+  var daemon: Boolean = false
+
   def info: protocol.ClientInfo =
     protocol.ClientInfo(uuid = uuid.toString, configName = configName, humanReadableName = humanReadableName)
 


### PR DESCRIPTION
This is intended to be for the Play fork plugin for example,
we don't want a dev-mode play server to keep sbt alive if
there aren't any IDEs or other user-visible clients open.
If Play wanted to be all clever it could set daemon mode
only after it goes idle itself (after no http requests for a
bit). Anyway, daemon mode can be toggled at any time so clients
can be as smart as they think is wise.