### PR TITLE
Bump to sbt 0.13.8-M3

### DIFF
--- a/integration-tests/src/main/scala/com/typesafe/sbtrc/it/loading/CanLoadSimpleProject.scala
+++ b/integration-tests/src/main/scala/com/typesafe/sbtrc/it/loading/CanLoadSimpleProject.scala
@@ -58,6 +58,10 @@ class CanLoadSimpleProject extends SbtClientTest {
     val compileKeys = waitWithError(compileKeysFuture, "Never received key lookup response!")
     assert(!compileKeys.isEmpty && compileKeys.head.key.name == "compile", s"Failed to find compile key: $compileKeys!")
 
+    val compileIncrementalKeysFuture = client.lookupScopedKey("compileIncremental")
+    val compileIncrementalKeys = waitWithError(compileIncrementalKeysFuture, "Never received key lookup response!")
+    assert(!compileIncrementalKeys.isEmpty && compileIncrementalKeys.head.key.name == "compileIncremental", s"Failed to find compile key: $compileIncrementalKeys!")
+
     // Here we check autocompletions:
     val completes = waitWithError(client.possibleAutocompletions("hel", 0), "Autocompletions not returned in time.")
     assert(completes.exists(_.append == "p"), "Failed to autocomplete `help` command.")
@@ -173,7 +177,7 @@ class CanLoadSimpleProject extends SbtClientTest {
 
     def withCompileTaskResult(body: Future[Unit] => Unit): Unit = {
       val result = Promise[Unit]
-      val compileWatchSub: Subscription = (client.rawWatch(TaskKey[Unit](compileKeys.head)) { (a: ScopedKey, b: TaskResult) =>
+      val compileWatchSub: Subscription = (client.rawWatch(TaskKey[Unit](compileIncrementalKeys.head)) { (a: ScopedKey, b: TaskResult) =>
         result.tryComplete(b.resultWithCustomThrowable[Unit, CompileFailedException])
       })(keepEventsInOrderExecutor)
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -25,7 +25,7 @@ object Dependencies {
   }
 
   // Reference versions
-  val sbt13Version = "0.13.7"
+  val sbt13Version = "0.13.8-M3"
   val sbt13ScalaVersion = getScalaVersionForSbtVersion(sbt13Version)
   val sbtAtmosDefaultVersion = "0.3.1"
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8-M1
+sbt.version=0.13.8-M3


### PR DESCRIPTION
Fix compile error tests for sbt 0.13.8-M3 and new `compileIncremental` split.