### PR TITLE
Improve unknown message type handling

### DIFF
--- a/client/src/main/scala/sbt/client/impl/SimpleClient.scala
+++ b/client/src/main/scala/sbt/client/impl/SimpleClient.scala
@@ -463,7 +463,9 @@ private[client] final class SimpleSbtClient(override val channel: SbtChannel) ex
         case protocol.ErrorResponse(msg) =>
           requestHandler.protocolError(replyTo, msg)
         case protocol.ReceivedResponse() => // silently ignore
-        case _ => System.err.println(s"Unhandled response $replyTo $response")
+        case _ =>
+          if (System.getProperty("sbt.client.debug") == "true")
+            System.err.println(s"Unhandled response $replyTo $response")
       }
     }
   }

--- a/protocol-test/src/test/scala/sbt/protocol/ProtocolTest.scala
+++ b/protocol-test/src/test/scala/sbt/protocol/ProtocolTest.scala
@@ -135,6 +135,7 @@ class ProtocolTest {
       // Requests
       protocol.DaemonRequest(true),
       protocol.KillServerRequest(),
+      protocol.UnknownMessage(SerializedValue.fromJsonString("""{ "foo" : 42 }""")),
       protocol.ReadLineRequest(42, "HI", true),
       protocol.ReadLineResponse(Some("line")),
       protocol.ConfirmRequest(43, "msg"),

--- a/server/src/main/scala/sbt/server/SbtClientHandler.scala
+++ b/server/src/main/scala/sbt/server/SbtClientHandler.scala
@@ -89,6 +89,16 @@ class SbtClientHandler(
           // TODO - other notifications?
           log.log(s"Response: $replyTo - $msg")
           interactionManager.error(replyTo, msg.error)
+        case Envelope(serial, replyTo, msg: UnknownMessage) =>
+          log.log(s"Ignoring unknown message: ${msg.serialized.toJsonString}")
+          // If this was an event it'd be a little strange to
+          // respond, but for now clients don't send events
+          // to the server so we can safely throw an error.
+          // check replyTo == 0 for paranoia in case the
+          // unknown message is a response, even though
+          // replyTo != 0 should be impossible.
+          if (replyTo == 0)
+            reply(serial, ErrorResponse(s"Unknown message type or could not parse message"))
         case Envelope(_, _, msg) =>
           sys.error("Unable to handle client request: " + msg)
       }


### PR DESCRIPTION
 * don't print to stderr unless sbt.client.debug=true
   (we could do something fancier with configurable logging someday)
 * pass through unknown messages as UnknownMessage, which allows
   clients to see them and decide how to respond or just print them
   out for debugging. Previously we converted them all to ErrorResponse,
   which was sort of bogus since you'd get a spontaneous response
   instead of an event.

An important point about this setup is that unknown events and requests
are "allowed" (it's part of the protocol that you're supposed to ignore
them), while unknown responses are not (if the responses to a request change,
that isn't backward compatible). We still convert unknown responses to
ErrorResponse, and ignore UnknownMessage.