### PR TITLE
Add serialization logic for sbt.Attributed

### DIFF
--- a/commons/protocol/src/main/scala/sbt/protocol/Keys.scala
+++ b/commons/protocol/src/main/scala/sbt/protocol/Keys.scala
@@ -117,7 +117,6 @@ object Attributed {
         builder.beginEntry(attr)
         builder.putField("data", { b ⇒
           b.hintTag(dataPickler.tag)
-          b.hintStaticallyElidedType()
           dataPickler.pickle(attr.data, b)
         })
         builder.endEntry()

--- a/protocol-test/src/test/scala/sbt/protocol/TypeExpressionPicklerSpec.scala
+++ b/protocol-test/src/test/scala/sbt/protocol/TypeExpressionPicklerSpec.scala
@@ -31,6 +31,8 @@ class TypeExpressionPicklerTest {
   val projectRef = protocol.ProjectReference(build, "test")
   val scope = protocol.SbtScope(project = Some(projectRef))
   val scopedKey = protocol.ScopedKey(key, scope)
+  val seqAttributedFile = Seq(
+    protocol.Attributed(new java.io.File("/some.file")))
 
   @Test
   def testRoundtripAttributeKey: Unit = {
@@ -45,5 +47,10 @@ class TypeExpressionPicklerTest {
   @Test
   def testRoundtripScopedKey: Unit = {
     roundTrip(scopedKey)
+  }
+
+  @Test
+  def testRoundtripSeqAttributedFile: Unit = {
+    roundTrip(seqAttributedFile)
   }
 }

--- a/server/src/main/scala/sbt/server/DynamicConversion.scala
+++ b/server/src/main/scala/sbt/server/DynamicConversion.scala
@@ -36,11 +36,10 @@ private final case class ConcreteDynamicConversion(registered: Map[Manifest[_], 
   }
 
   override def convert[F](value: F)(implicit mf: Manifest[F]): Option[(_, Manifest[_])] = {
-    val ret = registered.get(mf).map { conversion =>
+    registered.get(mf).map { conversion =>
       val result = conversion.asInstanceOf[RegisteredConversion[F, _]].convert(value)
       (result, conversion.toManifest)
     }
-    ret orElse defaultConversionByManifest(value, mf)
   }
 
   override def register[F, T](convert: F => T)(implicit fromMf: Manifest[F], toMf: Manifest[T]): DynamicConversion = {
@@ -51,34 +50,6 @@ private final case class ConcreteDynamicConversion(registered: Map[Manifest[_], 
   override def ++(other: DynamicConversion): DynamicConversion = {
     other match {
       case c: ConcreteDynamicConversion => copy(registered = (registered ++ c.registered))
-    }
-  }
-
-  private def defaultConversionByManifest[F](value: F, mf: Manifest[F]): Option[(_, Manifest[_])] = {
-    mf.runtimeClass match {
-      case Classes.SeqSubClass() =>
-        defaultConversionForSeq(value.asInstanceOf[Seq[_]], mf.typeArguments.head)
-      case _ =>
-        None
-    }
-  }
-
-  private def defaultConversionForSeq[T](xs: Seq[_], mf: Manifest[T]): Option[(Seq[_], Manifest[_])] = {
-    mf.runtimeClass match {
-      case Conversions.original.Attributed =>
-        defaultConversionForSeqAtt(xs.asInstanceOf[Seq[sbt.Attributed[_]]], mf.typeArguments.head.runtimeClass)
-      case _ =>
-        None
-    }
-  }
-
-  private def defaultConversionForSeqAtt(atts: Seq[sbt.Attributed[_]], klass: Class[_]): Option[(Seq[protocol.Attributed[_]], Manifest[_])] = {
-    klass match {
-      case Classes.FileClass =>
-        val mapped = atts.asInstanceOf[Seq[sbt.Attributed[File]]] map SbtToProtocolUtils.attributedToProtocol
-        Some((mapped, manifest[Seq[protocol.Attributed[File]]]))
-      case _ =>
-        None
     }
   }
 }

--- a/server/src/main/scala/sbt/server/DynamicSerialization.scala
+++ b/server/src/main/scala/sbt/server/DynamicSerialization.scala
@@ -19,7 +19,6 @@ private object Classes {
   val ListClass = classOf[List[_]]
   val SeqClass = classOf[Seq[_]]
   val NilClass = Nil.getClass
-  // val AttributedClass = classOf[sbt.Attributed[_]]
   val URIClass = classOf[java.net.URI]
   val ThrowableClass = classOf[Throwable]
 
@@ -35,8 +34,11 @@ private object Classes {
   object VectorSubClass extends SubClass(VectorClass)
   object ListSubClass extends SubClass(ListClass)
   object SeqSubClass extends SubClass(SeqClass)
-  // val AttributedClass = classOf[sbt.Attributed[_]]
   object ThrowableSubClass extends SubClass(ThrowableClass)
+
+  object protocol {
+    val Attributed = classOf[sbt.protocol.Attributed[_]]
+  }
 }
 
 // placeholder value for not serializable task results;
@@ -209,7 +211,7 @@ private object ConcreteDynamicSerialization {
       case Classes.FloatClass => makeSerializer[Seq[Float]]
       case Classes.DoubleClass => makeSerializer[Seq[Double]]
       case Classes.URIClass => makeSerializer[Seq[java.net.URI]]
-      case Conversions.protocol.Attributed => defaultSerializerForSeqAttributed(mf.typeArguments.head.runtimeClass)
+      case Classes.protocol.Attributed => defaultSerializerForSeqAttributed(mf.typeArguments.head.runtimeClass)
       case Classes.ThrowableSubClass() => makeSerializer[Seq[java.lang.Throwable]]
       case _ =>
         None

--- a/server/src/main/scala/sbt/server/SbtToProtocolUtils.scala
+++ b/server/src/main/scala/sbt/server/SbtToProtocolUtils.scala
@@ -138,4 +138,8 @@ object SbtToProtocolUtils {
   def attributedToProtocol[T](att: sbt.Attributed[T]): protocol.Attributed[T] = {
     protocol.Attributed(att.data)
   }
+
+  def seqAttributedFileToProtocol(attrs: Seq[sbt.Attributed[File]]): Seq[protocol.Attributed[File]] = {
+    attrs.map(attributedToProtocol)
+  }
 }

--- a/server/src/main/scala/sbt/server/SbtToProtocolUtils.scala
+++ b/server/src/main/scala/sbt/server/SbtToProtocolUtils.scala
@@ -134,4 +134,8 @@ object SbtToProtocolUtils {
     protocol.ModuleId(organization = moduleId.getOrganisation(), name = moduleId.getName(),
       attributes = moduleId.getAttributes().asInstanceOf[java.util.Map[String, String]].asScala.toMap)
   }
+
+  def attributedToProtocol[T](att: sbt.Attributed[T]): protocol.Attributed[T] = {
+    protocol.Attributed(att.data)
+  }
 }

--- a/server/src/main/scala/sbt/server/Serializations.scala
+++ b/server/src/main/scala/sbt/server/Serializations.scala
@@ -15,6 +15,15 @@ object Serializations {
 }
 
 object Conversions {
+
+  object original {
+    val Attributed = classOf[sbt.Attributed[_]]
+  }
+
+  object protocol {
+    val Attributed = classOf[sbt.protocol.Attributed[_]]
+  }
+
   val key = AttributeKey[DynamicConversion]("Aggregate of registered conversions")
 
   def extractOpt(state: State): Option[DynamicConversion] = state get key

--- a/server/src/main/scala/sbt/server/Serializations.scala
+++ b/server/src/main/scala/sbt/server/Serializations.scala
@@ -15,15 +15,6 @@ object Serializations {
 }
 
 object Conversions {
-
-  object original {
-    val Attributed = classOf[sbt.Attributed[_]]
-  }
-
-  object protocol {
-    val Attributed = classOf[sbt.protocol.Attributed[_]]
-  }
-
   val key = AttributeKey[DynamicConversion]("Aggregate of registered conversions")
 
   def extractOpt(state: State): Option[DynamicConversion] = state get key

--- a/server/src/main/scala/sbt/server/Serializations.scala
+++ b/server/src/main/scala/sbt/server/Serializations.scala
@@ -44,7 +44,8 @@ object Conversions {
     import SbtToProtocolUtils._
     val conversions = Seq(
       register(compileFailedExceptionToProtocol),
-      register(moduleIdToProtocol))
+      register(moduleIdToProtocol),
+      register(seqAttributedFileToProtocol))
     conversions.foldLeft(base) { (sofar, next) =>
       next(sofar)
     }


### PR DESCRIPTION
- sbt.Attributed needs to be converted to protocol.Attributed, which is
  sent over the wire
- protocol.Attributed does not yet contain a field for the AttributeMap
  that is stored in sbt.Attributed
- protocol.Attributed contains a manually written (un)pickler because it
  is not possible to generate them for types that take type parameter
- so far, it is only possible to convert/serialize a Seq[Attributed[File]]