### PR TITLE
Change "ridiculously huge message" from 1M to 100M

### DIFF
--- a/commons/protocol/src/main/scala/sbt/impl/ipc/IPC.scala
+++ b/commons/protocol/src/main/scala/sbt/impl/ipc/IPC.scala
@@ -95,7 +95,7 @@ abstract class Peer(protected val socket: Socket) {
     val length = in.readInt()
     val serial = in.readLong()
     val replyTo = in.readLong()
-    if (length > (1024 * 1024))
+    if (length > (1024 * 1024 * 100))
       throw new RuntimeException("Ridiculously huge message (" + length + " bytes)")
     val bytes = new Array[Byte](length)
     in.readFully(bytes)


### PR DESCRIPTION
1M is perfectly possible to encounter with a large project or build structure or whatever. It's catastrophic to hit this limit so make it huge.
