### PR TITLE
Enable UpdateReport serializer and update dependencies

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -51,13 +51,13 @@ object Dependencies {
   val coreNext210          = sbtOrg % "core-next_2.10" % coreNextVersion
   val coreNextPlugin13     = Defaults.sbtPluginExtra(sbtOrg % "sbt-core-next" % coreNextVersion, "0.13", "2.10")
 
-  val serializationVersion = "0.1.0"
+  val serializationVersion = "0.1.1"
   val serialization210 = "org.scala-sbt" % "serialization_2.10" % serializationVersion
   val serialization211 = "org.scala-sbt" % "serialization_2.11" % serializationVersion
   val serializationLib = "org.scala-sbt" %% "serialization" % serializationVersion
 
   // These are needed for integration tests. Use the values used by sbt/serialization
-  val picklingVersion = "0.10.0-M4"
+  val picklingVersion = "0.10.0"
   val pickling210 = "org.scala-lang.modules" % "scala-pickling_2.10" % picklingVersion
   val pickling211 = "org.scala-lang.modules" % "scala-pickling_2.11" % picklingVersion
   val pickling = "org.scala-lang.modules" %% "scala-pickling" % picklingVersion

--- a/server/src/main/scala/sbt/server/DynamicSerialization.scala
+++ b/server/src/main/scala/sbt/server/DynamicSerialization.scala
@@ -273,7 +273,8 @@ private object NonTrivialSerializers {
       RegisteredSerializer[MinimalBuildStructure],
       RegisteredSerializer[CompileFailedException],
       RegisteredSerializer[ModuleId],
-      RegisteredSerializer[protocol.Attributed[File]])
+      RegisteredSerializer[protocol.Attributed[File]],
+      RegisteredSerializer[sbt.UpdateReport])
     serializers.foldLeft(base) { (sofar, next) =>
       sofar.register(next.serializer)(next.manifest)
     }


### PR DESCRIPTION
Since sbt-remote-control moved to SBT 0.13.8 it seems reasonable to enable serialization for UpdateReport. If there is a general way to enable serialization for all SBT types that have picklers tell me and I will update this PR.