### PR TITLE
Remove duplicate log lines from sbt-server

### DIFF
--- a/project/integration.scala
+++ b/project/integration.scala
@@ -98,11 +98,10 @@ final case class IntegrationContext(launchJar: File,
     sbt.IO.touch(logFile)
     val pw = new java.io.PrintWriter(new java.io.FileWriter(logFile))
     val fileLogger = ConsoleLogger(pw)
-    // TODO - Filter logs so we're not so chatty on the console.
-    // Start printing dots to the screen.
     // First clean the old test....
     IO delete cwd
     IO createDirectory cwd
+    // Start printing dots to the screen.
     object StatusDot extends TimerTask {
       // TODO - This should be sbt-server friendly
       override def run(): Unit = print(".")
@@ -115,15 +114,14 @@ final case class IntegrationContext(launchJar: File,
       case 0 =>
         println()
         t.cancel()
-        streams.log.info(s" [IT] $name result: SUCCESS")
+        streams.log.info(s" [IT] $name result: ${scala.Console.GREEN}SUCCESS${scala.Console.RESET}")
         IntegrationTestResult(name, true, logFile)
       case n =>
         pw.close()
         t.cancel()
         println()
-        streams.log.error(s" [IT] $name result: FAILURE   - $n")
+        streams.log.error(s" [IT] $name result: ${scala.Console.RED}FAILURE${scala.Console.RESET}   - $n")
         // Here we dump the file logs onto the screen.
-        // TODO - this should be sbt-server friendly
         IO.readLines(logFile) foreach (l => streams.log.error(l))
         IntegrationTestResult(name, false, logFile)
     })

--- a/server/src/main/scala/sbt/server/ServerEngine.scala
+++ b/server/src/main/scala/sbt/server/ServerEngine.scala
@@ -245,7 +245,9 @@ class ServerEngine(requestQueue: ServerEngineQueue,
     def globalLogging(backing: GlobalLogBacking): GlobalLogging =
       GlobalLogging(
         full = eventLogger, // TODO - Send this to the "writer" we get in newLogger.
-        console = eventLogger.consoleOut,
+        // TODO - We may actually want to use a void console logger here.
+        //console = eventLogger.consoleOut,
+        console = eventLogger.voidConsoleOut,
         backed = eventLogger,
         backing = backing,
         // TODO - This needs to be fixed.  Does not use the correct writer to enable "last" to work properly.


### PR DESCRIPTION
This removes duplicated log lines by ignoring lines that are sent to a semantic logger AND println.